### PR TITLE
fix: add uma proposal interface

### DIFF
--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -207,6 +207,18 @@ export interface RealityOracleProposal {
   endTime: number | undefined;
 }
 
+export interface UmaOracleProposal {
+  dao: string;
+  oracle: string;
+  rules: number;
+  expiration: number;
+  proposalId: string;
+  transactions: SafeTransaction[];
+  txHashes: string[];
+  minimumBond: BigNumber | undefined;
+  explanation: string;
+}
+
 export interface SafeAsset {
   address: string;
   name: string;


### PR DESCRIPTION
Signed-off-by: John Shutt <pemulis@users.noreply.github.com>

Adds an interface for UMA proposals.

We'll need to change `getModuleDetails` since the details are different for UMA vs. Reality but the interface should have all of the information we need for the UMA version (plus some extra stuff that doesn't appear to be used).
