### PR TITLE
Improve UMA module and outcome handling

### DIFF
--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -597,6 +597,7 @@
       "changeOutcome": "Change outcome",
       "executeTxs": "Execute transaction batch {0} of {1}",
       "executed": "All transactions have been executed",
+      "noTransactions": "There are no transactions to execute",
       "rejected": "Proposal rejected",
       "error": "Something went wrong",
       "connectWallet": "Connect wallet to see execution details",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -606,6 +606,7 @@
       "proposalPassed": "Did the proposal pass?",
       "expired": "The proposal has expired",
       "approveBond": "Approve bond",
+      "confirmVoteResults": "Click if the proposal passed",
       "executeTxsUma": "Execute transaction batch",
       "deleteDisputedProposal": "Delete disputed proposal"
     }

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -608,7 +608,8 @@
       "approveBond": "Approve bond",
       "confirmVoteResults": "Click to confirm the proposal passed",
       "executeTxsUma": "Execute transaction batch",
-      "deleteDisputedProposal": "Delete disputed proposal"
+      "deleteDisputedProposal": "Delete disputed proposal",
+      "deleteRejectedProposal": "Delete rejected proposal"
     }
   },
   "poap": {

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -597,7 +597,6 @@
       "changeOutcome": "Change outcome",
       "executeTxs": "Execute transaction batch {0} of {1}",
       "executed": "All transactions have been executed",
-      "executedUma": "All transactions have been executed\n\n(Note: If the transactions in this proposal are exactly the same as the transactions in another proposal that has already executed, you will need to propose the transactions manually through your Safe's UMA Optimistic Governor module)",
       "rejected": "Proposal rejected",
       "error": "Something went wrong",
       "connectWallet": "Connect wallet to see execution details",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -606,7 +606,7 @@
       "proposalPassed": "Did the proposal pass?",
       "expired": "The proposal has expired",
       "approveBond": "Approve bond",
-      "confirmVoteResults": "Click if the proposal passed",
+      "confirmVoteResults": "Click to confirm the proposal passed",
       "executeTxsUma": "Execute transaction batch",
       "deleteDisputedProposal": "Delete disputed proposal"
     }

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -597,6 +597,7 @@
       "changeOutcome": "Change outcome",
       "executeTxs": "Execute transaction batch {0} of {1}",
       "executed": "All transactions have been executed",
+      "executedUma": "All transactions have been executed\n\n(Note: If the transactions in this proposal are exactly the same as the transactions in another proposal that has already executed, you will need to propose the transactions manually through your Safe's UMA Optimistic Governor module)",
       "rejected": "Proposal rejected",
       "error": "Something went wrong",
       "connectWallet": "Connect wallet to see execution details",

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -251,7 +251,6 @@ const deleteDisputedProposal = async () => {
   }
 };
 
-// TODO: Implement button for deleting rejected proposal.
 const deleteRejectedProposal = async () => {
   if (!getInstance().isAuthenticated.value) return;
   action2InProgress.value = 'delete-rejected-proposal';
@@ -339,7 +338,6 @@ const questionState = computed(() => {
   // Proposal can be deleted if it has been rejected.
   if (proposalEvent.isDisputed && proposalEvent.resolvedPrice == 0)
     return QuestionStates.proposalRejected;
-  // TODO: Allow user to delete proposal but do not show option to re-propose.
 
   return QuestionStates.error;
 });
@@ -424,6 +422,15 @@ onMounted(async () => {
         @click="deleteDisputedProposal"
       >
         {{ $t('safeSnap.labels.deleteDisputedProposal') }}
+      </BaseButton>
+    </div>
+
+    <div v-if="questionState === questionStates.proposalRejected" class="my-4">
+      <BaseButton
+        :loading="action2InProgress === 'delete-rejected-proposal'"
+        @click="deleteRejectedProposal"
+      >
+        {{ $t('safeSnap.labels.deleteRejectedProposal') }}
       </BaseButton>
     </div>
 

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -39,13 +39,14 @@ const QuestionStates = {
   noWalletConnection: 0,
   loading: 1,
   waitingForVoteConfirmation: 2,
-  waitingForProposal: 3,
-  waitingForLiveness: 4,
-  proposalApproved: 5,
-  proposalRejected: 6,
-  completelyExecuted: 7,
-  disputedButNotResolved: 8,
-  disputedResolvedValid: 9
+  noTransactions: 3,
+  waitingForProposal: 4,
+  waitingForLiveness: 5,
+  proposalApproved: 6,
+  proposalRejected: 7,
+  completelyExecuted: 8,
+  disputedButNotResolved: 9,
+  disputedResolvedValid: 10
 };
 Object.freeze(QuestionStates);
 
@@ -302,6 +303,9 @@ const questionState = computed(() => {
 
   if (!questionDetails.value) return QuestionStates.error;
 
+  if (questionDetails.value.noTransactions)
+    return QuestionStates.noTransactions;
+
   const ts = (Date.now() / 1e3).toFixed();
   const { proposalEvent, proposalExecuted } = questionDetails.value;
 
@@ -372,6 +376,11 @@ onMounted(async () => {
         {{ $t('safeSnap.labels.confirmVoteResults') }}
       </BaseButton>
     </div>
+
+    <div v-if="questionState === questionStates.noTransactions" class="my-4">
+      {{ $t('safeSnap.labels.noTransactions') }}
+    </div>
+
     <div
       v-if="
         questionState === questionStates.waitingForProposal &&
@@ -386,6 +395,7 @@ onMounted(async () => {
         {{ $t('safeSnap.labels.approveBond') }}
       </BaseButton>
     </div>
+
     <div
       v-if="
         questionState === questionStates.waitingForProposal &&

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -64,6 +64,7 @@ export const getModuleDetailsUma = async (
   symbol: string;
   userBalance: BigNumber;
   needsBondApproval: boolean;
+  noTransactions: boolean;
   proposalEvent: any;
   proposalExecuted: boolean;
 }> => {
@@ -108,6 +109,23 @@ export const getModuleDetailsUma = async (
       ]
     );
     timestamp = await moduleContract.proposalHashes(proposalHash);
+  } else {
+    return {
+      dao: moduleDetails[0][0],
+      oracle: moduleDetails[1][0],
+      rules: moduleDetails[2][0],
+      minimumBond: minimumBond,
+      expiration: moduleDetails[4][0],
+      allowance: bondDetails.currentUserBondAllowance,
+      collateral: bondDetails.collateral,
+      decimals: bondDetails.decimals,
+      symbol: bondDetails.symbol,
+      userBalance: bondDetails.currentUserBalance,
+      needsBondApproval: needsApproval,
+      noTransactions: true,
+      proposalEvent: {},
+      proposalExecuted: false
+    };
   }
 
   // Search for requests with matching ancillary data
@@ -165,6 +183,7 @@ export const getModuleDetailsUma = async (
     moduleContract.filters.TransactionExecuted(proposalHash)
   );
   const proposalExecuted = executionEvents.length > 0;
+
   return {
     dao: moduleDetails[0][0],
     oracle: moduleDetails[1][0],
@@ -177,6 +196,7 @@ export const getModuleDetailsUma = async (
     symbol: bondDetails.symbol,
     userBalance: bondDetails.currentUserBalance,
     needsBondApproval: needsApproval,
+    noTransactions: false,
     proposalEvent: proposalEvent[0],
     proposalExecuted: proposalExecuted
   };


### PR DESCRIPTION
Signed-off-by: John Shutt <pemulis@users.noreply.github.com>

This PR resolves three outstanding issues:

1. Adds a button for the user to confirm that the proposal passed before showing a button to request execution.
2. Adds a button to delete a rejected proposal.
3. Adds handling for the case where there are no transactions in the proposal.

Notes:

- We have not been able to test the button to delete a rejected proposal since the Goerli Finder is pointing to the actual voting contract, rather than the mock oracle, for UMA V2 testing. We should be able to test this next week. In the meantime, a code review should be adequate. This button only exists to handle the edge case of a bad proposal that was not deleted during the dispute period, which is later duplicated by a good proposal, which requires you to delete the bad proposal (with the identical hash) before making the good proposal.
- We still have bad UX when a proposal has been executed and then a duplicate proposal is made in the future. Our code detects the earlier execution and does not present a button to propose again. Our immediate plan is to note this edge case in documentation, and direct users to make the proposal manually through their UMA Optimistic Governor interface in Zodiac. Our longer-term (2 month) plan is to add a `ProposalExecuted` event with a timestamp to the next iteration of the `OptimisticGovernor` contract, which will use the `OptimisticArbitrator` rather than the `OptimisticOracle`. We will encourage all users to migrate to `OptimisticGovernorV2`, anyway, and the migration process is relatively easy since Zodiac modules are...modular, and you can even have two Zodiac modules running side by side.