### PR TITLE
feat: use explanations to track proposal uniqueness

### DIFF
--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -304,17 +304,18 @@ const questionState = computed(() => {
     return QuestionStates.noTransactions;
 
   const ts = (Date.now() / 1e3).toFixed();
-  const { proposalEvent, proposalExecuted } = questionDetails.value;
+  const { proposalEvent, proposalExecuted, activeProposal } =
+    questionDetails.value;
 
   // If proposal has already been executed, prevents user from proposing again.
   if (proposalExecuted) return QuestionStates.completelyExecuted;
 
   // User can confirm vote results if not done already and there is no proposal yet.
-  if (!proposalEvent && !voteResultsConfirmed.value)
+  if (!activeProposal && !voteResultsConfirmed.value)
     return QuestionStates.waitingForVoteConfirmation;
 
   // Proposal can be made if it has not been made already and user confirmed vote results.
-  if (!proposalEvent && voteResultsConfirmed)
+  if (!activeProposal && voteResultsConfirmed)
     return QuestionStates.waitingForProposal;
 
   // Proposal can be deleted if it has been rejected.

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -167,6 +167,7 @@ const submitProposal = async () => {
     const proposalSubmission = plugin.submitProposal(
       getInstance().web3,
       props.umaAddress,
+      props.ipfs,
       getTransactions()
     );
     await proposalSubmission.next();

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -119,7 +119,7 @@ const updateDetails = async () => {
       props.network,
       props.umaAddress,
       props.proposal.id,
-      props.proposal.ifps,
+      props.proposal.ipfs,
       getTransactions()
     );
   } catch (e) {

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -167,7 +167,7 @@ const submitProposal = async () => {
     const proposalSubmission = plugin.submitProposal(
       getInstance().web3,
       props.umaAddress,
-      // props.ipfs,
+      props.ipfs,
       getTransactions()
     );
     await proposalSubmission.next();

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -308,13 +308,6 @@ const questionState = computed(() => {
   // If proposal has already been executed, prevents user from proposing again.
   if (proposalExecuted) return QuestionStates.completelyExecuted;
 
-  // Proposal can be deleted if it has been rejected.
-  if (proposalEvent.isDisputed && proposalEvent.resolvedPrice == 0)
-    return QuestionStates.proposalRejected;
-
-  // If disputed, a proposal can be deleted to enable a proposal to be proposed again.
-  if (proposalEvent.isDisputed) return QuestionStates.disputedButNotResolved;
-
   // User can confirm vote results if not done already and there is no proposal yet.
   if (!proposalEvent && !voteResultsConfirmed.value)
     return QuestionStates.waitingForVoteConfirmation;
@@ -322,6 +315,13 @@ const questionState = computed(() => {
   // Proposal can be made if it has not been made already and user confirmed vote results.
   if (!proposalEvent && voteResultsConfirmed)
     return QuestionStates.waitingForProposal;
+
+  // Proposal can be deleted if it has been rejected.
+  if (proposalEvent.isDisputed && proposalEvent.resolvedPrice == 0)
+    return QuestionStates.proposalRejected;
+
+  // If disputed, a proposal can be deleted to enable a proposal to be proposed again.
+  if (proposalEvent.isDisputed) return QuestionStates.disputedButNotResolved;
 
   // Proposal has been made and is waiting for liveness period to complete.
   if (!proposalEvent.isExpired) return QuestionStates.waitingForLiveness;

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -167,7 +167,7 @@ const submitProposal = async () => {
     const proposalSubmission = plugin.submitProposal(
       getInstance().web3,
       props.umaAddress,
-      props.ipfs,
+      // props.ipfs,
       getTransactions()
     );
     await proposalSubmission.next();

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -167,7 +167,7 @@ const submitProposal = async () => {
     const proposalSubmission = plugin.submitProposal(
       getInstance().web3,
       props.umaAddress,
-      props.ipfs,
+      props.proposal.ipfs,
       getTransactions()
     );
     await proposalSubmission.next();

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -45,70 +45,6 @@ const QuestionStates = {
 };
 Object.freeze(QuestionStates);
 
-const loading = ref(true);
-const actionInProgress = ref(false);
-const action2InProgress = ref(false);
-const voteResultsConfirmed = ref(false);
-const questionStates = ref(QuestionStates);
-const questionDetails = ref(undefined);
-
-const usingMetaMask = computed(() => {
-  return window.ethereum && getInstance().provider.value?.isMetaMask;
-});
-
-const connectedToRightChain = computed(() => {
-  return getInstance().provider.value?.chainId === parseInt(props.network);
-});
-
-const networkName = computed(() => {
-  return networks[props.network].name;
-});
-
-const questionState = computed(() => {
-  if (!web3.value.account) return QuestionStates.noWalletConnection;
-
-  if (loading.value) return QuestionStates.loading;
-
-  if (!questionDetails.value) return QuestionStates.error;
-
-  if (questionDetails.value.noTransactions)
-    return QuestionStates.noTransactions;
-
-  const ts = (Date.now() / 1e3).toFixed();
-  const { proposalEvent, proposalExecuted } = questionDetails.value;
-
-  // If proposal has already been executed, prevents user from proposing again.
-  if (proposalExecuted) return QuestionStates.completelyExecuted;
-
-  // User can confirm vote results if not done already and there is no proposal yet.
-  if (!proposalEvent && !voteResultsConfirmed.value)
-    return QuestionStates.waitingForVoteConfirmation;
-
-  // Proposal can be made if it has not been made already and user confirmed vote results.
-  if (!proposalEvent && voteResultsConfirmed)
-    return QuestionStates.waitingForProposal;
-
-  // Proposal can be deleted if it has been rejected.
-  if (proposalEvent.isDisputed && proposalEvent.resolvedPrice == 0)
-    return QuestionStates.proposalRejected;
-
-  // If disputed, a proposal can be deleted to enable a proposal to be proposed again.
-  if (proposalEvent.isDisputed) return QuestionStates.disputedButNotResolved;
-
-  // Proposal has been made and is waiting for liveness period to complete.
-  if (!proposalEvent.isExpired) return QuestionStates.waitingForLiveness;
-
-  // Proposal is approved if it expires without a dispute and hasn't been settled.
-  if (proposalEvent.isExpired && !proposalEvent.isSettled)
-    return QuestionStates.proposalApproved;
-
-  // Proposal is approved if it has been settled without a disputer and hasn't been executed.
-  if (proposalEvent.isSettled && !proposalEvent.isDisputed && !proposalExecuted)
-    return QuestionStates.proposalApproved;
-
-  return QuestionStates.error;
-});
-
 const ensureRightNetwork = async chainId => {
   const chainIdInt = parseInt(chainId);
   const connectedToChainId = getInstance().provider.value?.chainId;
@@ -160,6 +96,13 @@ const ensureRightNetwork = async chainId => {
   }
 };
 
+const loading = ref(true);
+const actionInProgress = ref(false);
+const action2InProgress = ref(false);
+const voteResultsConfirmed = ref(false);
+const questionStates = ref(QuestionStates);
+const questionDetails = ref(undefined);
+
 const getTransactions = () => {
   return props.batches.map(batch => [
     batch.transactions[0].to,
@@ -179,7 +122,6 @@ const updateDetails = async () => {
       props.proposal.ipfs,
       getTransactions()
     );
-    console.log('question state:', questionState);
   } catch (e) {
     console.error(e);
   } finally {
@@ -338,6 +280,63 @@ const deleteRejectedProposal = async () => {
     action2InProgress.value = null;
   }
 };
+
+const usingMetaMask = computed(() => {
+  return window.ethereum && getInstance().provider.value?.isMetaMask;
+});
+
+const connectedToRightChain = computed(() => {
+  return getInstance().provider.value?.chainId === parseInt(props.network);
+});
+
+const networkName = computed(() => {
+  return networks[props.network].name;
+});
+
+const questionState = computed(() => {
+  if (!web3.value.account) return QuestionStates.noWalletConnection;
+
+  if (loading.value) return QuestionStates.loading;
+
+  if (!questionDetails.value) return QuestionStates.error;
+
+  if (questionDetails.value.noTransactions)
+    return QuestionStates.noTransactions;
+
+  const ts = (Date.now() / 1e3).toFixed();
+  const { proposalEvent, proposalExecuted } = questionDetails.value;
+
+  // If proposal has already been executed, prevents user from proposing again.
+  if (proposalExecuted) return QuestionStates.completelyExecuted;
+
+  // User can confirm vote results if not done already and there is no proposal yet.
+  if (!proposalEvent && !voteResultsConfirmed.value)
+    return QuestionStates.waitingForVoteConfirmation;
+
+  // Proposal can be made if it has not been made already and user confirmed vote results.
+  if (!proposalEvent && voteResultsConfirmed)
+    return QuestionStates.waitingForProposal;
+
+  // Proposal can be deleted if it has been rejected.
+  if (proposalEvent.isDisputed && proposalEvent.resolvedPrice == 0)
+    return QuestionStates.proposalRejected;
+
+  // If disputed, a proposal can be deleted to enable a proposal to be proposed again.
+  if (proposalEvent.isDisputed) return QuestionStates.disputedButNotResolved;
+
+  // Proposal has been made and is waiting for liveness period to complete.
+  if (!proposalEvent.isExpired) return QuestionStates.waitingForLiveness;
+
+  // Proposal is approved if it expires without a dispute and hasn't been settled.
+  if (proposalEvent.isExpired && !proposalEvent.isSettled)
+    return QuestionStates.proposalApproved;
+
+  // Proposal is approved if it has been settled without a disputer and hasn't been executed.
+  if (proposalEvent.isSettled && !proposalEvent.isDisputed && !proposalExecuted)
+    return QuestionStates.proposalApproved;
+
+  return QuestionStates.error;
+});
 
 onMounted(async () => {
   await updateDetails();

--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -115,6 +115,7 @@ export const UMA_MODULE_ABI = [
   'event SetRules(string indexed rules)',
   'event TargetSet(address indexed previousTarget, address indexed newTarget)',
   'event TransactionExecuted(bytes32 indexed proposalHash, uint256 indexed transactionIndex)',
+  'event ProposalExecuted(bytes32 indexed proposalHash, uint256 indexed proposalTime)',
   'event TransactionsProposed(address indexed proposer, uint256 indexed proposalTime, tuple(tuple(address to, uint8 operation, uint256 value, bytes data)[] transactions, uint256 requestTime) proposal, bytes32 proposalHash, bytes explanation, uint256 challengeWindowEnds)',
   'function PROPOSAL_HASH_KEY() view returns (bytes)',
   'function PROPOSAL_VALID_RESPONSE() view returns (int256)',

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -280,14 +280,12 @@ export default class Plugin {
   ) {
     console.log('explanation in submit function:', explanation);
     console.log('transactions in submit function:', transactions);
-    const explanationBytes = toUtf8Bytes(explanation);
-    console.log('explanationBytes:', explanationBytes);
     const tx = await sendTransaction(
       web3,
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions, explanationBytes]
+      [transactions, explanation]
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -278,10 +278,7 @@ export default class Plugin {
     explanation: string,
     transactions: any
   ) {
-    console.log('explanation in submit function:', explanation);
-    console.log('transactions in submit function:', transactions);
     const explanationBytes = toUtf8Bytes(explanation);
-    console.log('explanationBytes:', explanationBytes);
     const tx = await sendTransaction(
       web3,
       moduleAddress,

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -283,7 +283,7 @@ export default class Plugin {
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions, '']
+      [transactions, '0x']
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -280,12 +280,14 @@ export default class Plugin {
   ) {
     console.log('explanation in submit function:', explanation);
     console.log('transactions in submit function:', transactions);
+    const explanationBytes = toUtf8Bytes(explanation);
+    console.log('explanationBytes:', explanationBytes);
     const tx = await sendTransaction(
       web3,
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions, explanation]
+      [transactions, explanationBytes]
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -278,12 +278,14 @@ export default class Plugin {
     explanation: string,
     transactions: any
   ) {
+    const explanationBytes = toUtf8Bytes(explanation);
+    console.log('explanationBytes:', explanationBytes);
     const tx = await sendTransaction(
       web3,
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions, '0x']
+      [transactions, explanationBytes]
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -279,6 +279,7 @@ export default class Plugin {
     transactions: any
   ) {
     console.log('explanation in submit function:', explanation);
+    console.log('transactions in submit function:', transactions);
     const explanationBytes = toUtf8Bytes(explanation);
     console.log('explanationBytes:', explanationBytes);
     const tx = await sendTransaction(

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -275,7 +275,7 @@ export default class Plugin {
   async *submitProposal(
     web3: any,
     moduleAddress: string,
-    // explanation: string,
+    explanation: string,
     transactions: any
   ) {
     const tx = await sendTransaction(
@@ -283,8 +283,7 @@ export default class Plugin {
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions]
-      // [transactions, explanation]
+      [transactions, explanation]
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -275,7 +275,7 @@ export default class Plugin {
   async *submitProposal(
     web3: any,
     moduleAddress: string,
-    explanation: string,
+    // explanation: string,
     transactions: any
   ) {
     const tx = await sendTransaction(
@@ -283,7 +283,8 @@ export default class Plugin {
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions, toUtf8Bytes(explanation)]
+      [transactions]
+      // [transactions, explanation]
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -278,6 +278,7 @@ export default class Plugin {
     explanation: string,
     transactions: any
   ) {
+    console.log('explanation in submit function:', explanation);
     const explanationBytes = toUtf8Bytes(explanation);
     console.log('explanationBytes:', explanationBytes);
     const tx = await sendTransaction(

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -271,13 +271,18 @@ export default class Plugin {
     console.log('[DAO module] submitted proposal:', receipt);
   }
 
-  async *submitProposal(web3: any, moduleAddress: string, transactions: any) {
+  async *submitProposal(
+    web3: any,
+    moduleAddress: string,
+    explanation: string,
+    transactions: any
+  ) {
     const tx = await sendTransaction(
       web3,
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions, '0x']
+      [transactions, explanation]
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -1,6 +1,7 @@
 import { Result } from '@ethersproject/abi';
 import { isAddress } from '@ethersproject/address';
 import { isHexString } from '@ethersproject/bytes';
+import { toUtf8Bytes } from '@ethersproject/strings';
 import { Contract } from '@ethersproject/contracts';
 import { BigNumber } from '@ethersproject/bignumber';
 import { _TypedDataEncoder } from '@ethersproject/hash';
@@ -282,7 +283,7 @@ export default class Plugin {
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions, explanation]
+      [transactions, toUtf8Bytes(explanation)]
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -283,7 +283,7 @@ export default class Plugin {
       moduleAddress,
       UMA_MODULE_ABI,
       'proposeTransactions',
-      [transactions, explanation]
+      [transactions, '']
       // [[["0xB8034521BB1a343D556e5005680B3F17FFc74BeD", 0, "0", "0x"]], '0x']
     );
     yield;

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -158,7 +158,7 @@ export const getModuleDetailsUma = async (
   const thisModuleProposalEvents = proposalEvents.filter(
     event =>
       event.args?.ancillaryData === ancillaryData &&
-      event.args?.timestamp == proposalHashTimestamp
+      event.args?.timestamp.toString() === proposalHashTimestamp.toString()
   );
 
   console.log('this module proposal events:', thisModuleProposalEvents);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -156,7 +156,9 @@ export const getModuleDetailsUma = async (
   console.log('proposal events:', proposalEvents);
 
   const thisModuleProposalEvents = proposalEvents.filter(
-    event => event.args?.ancillaryData === ancillaryData
+    event =>
+      event.args?.ancillaryData === ancillaryData &&
+      event.args?.timestamp === proposalHashTimestamp
   );
 
   console.log('this module proposal events:', thisModuleProposalEvents);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -187,7 +187,7 @@ export const getModuleDetailsUma = async (
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
 
-  let proposalExecuted = false;
+  const proposalExecuted = false;
 
   if (thisModuleFullProposalEvents) {
     // Check if execution event matches this specific Snapshot proposal's IPFS CID.
@@ -202,8 +202,8 @@ export const getModuleDetailsUma = async (
       });
 
     // Set proposal executed to true if this Snapshot proposal was executed.
-    proposalExecuted =
-      executionEvents.length > 0 && transactionsProposedEvents.length > 0;
+    // proposalExecuted =
+    //   executionEvents.length > 0 && transactionsProposedEvents.length > 0;
   }
 
   return {

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -133,13 +133,15 @@ export const getModuleDetailsUma = async (
     };
   }
   // Check for active proposals
-  const proposalHashTimestamp = await moduleContract
-    .proposalHashes(proposalHash)
-    .then(value => BigNumber.from(value));
-  console.log('proposal hash timestamp:', proposalHashTimestamp);
+  const proposalHashTimestamp = await moduleContract.proposalHashes(
+    proposalHash
+  );
+  console.log(
+    'proposal hash timestamp:',
+    BigNumber.from(proposalHashTimestamp)
+  );
 
-  const activeProposal =
-    proposalHashTimestamp != '0x0000000000000000000000000000000000000000';
+  const activeProposal = BigNumber.from(proposalHashTimestamp).isZero;
   console.log('active proposal?', activeProposal);
 
   // Search for requests with matching ancillary data

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -144,9 +144,8 @@ export const getModuleDetailsUma = async (
   );
 
   const thisModuleProposalEvents = proposalEvents.filter(
-    event =>
-      event.args?.ancillaryData === ancillaryData &&
-      event.args?.timestamp == currentProposalHashTimestamp
+    event => event.args?.ancillaryData === ancillaryData /*&&
+      event.args?.timestamp == currentProposalHashTimestamp*/
   );
 
   // Get the full proposal events (with state and disputer).
@@ -183,28 +182,28 @@ export const getModuleDetailsUma = async (
   );
 
   // Check for execution events matching the Snapshot proposal hash.
-  // const executionEvents = await moduleContract.queryFilter(
-  //   moduleContract.filters.ProposalExecuted(proposalHash)
-  // );
+  const executionEvents = await moduleContract.queryFilter(
+    moduleContract.filters.ProposalExecuted(proposalHash)
+  );
 
-  const proposalExecuted = false;
+  let proposalExecuted = false;
 
-  // if (thisModuleFullProposalEvents) {
-  //   // Check if execution event matches this specific Snapshot proposal's IPFS CID.
-  //   const transactionsProposedEvents = await moduleContract
-  //     .queryFilter(moduleContract.filters.TransactionsProposed())
-  //     .then(result => {
-  //       return result.filter(
-  //         event =>
-  //           event.args?.explanation === toUtf8Bytes(explanation) &&
-  //           event.args?.proposalHash === proposalHash
-  //       );
-  //     });
+  if (thisModuleFullProposalEvents) {
+    // Check if execution event matches this specific Snapshot proposal's IPFS CID.
+    const transactionsProposedEvents = await moduleContract
+      .queryFilter(moduleContract.filters.TransactionsProposed())
+      .then(result => {
+        return result.filter(
+          event =>
+            event.args?.explanation === toUtf8Bytes(explanation) &&
+            event.args?.proposalHash === proposalHash
+        );
+      });
 
-  // Set proposal executed to true if this Snapshot proposal was executed.
-  // proposalExecuted =
-  //   executionEvents.length > 0 && transactionsProposedEvents.length > 0;
-  // }
+    // Set proposal executed to true if this Snapshot proposal was executed.
+    proposalExecuted =
+      executionEvents.length > 0 && transactionsProposedEvents.length > 0;
+  }
 
   return {
     dao: moduleDetails[0][0],

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -202,7 +202,7 @@ export const getModuleDetailsUma = async (
 
   const thisProposalTransactionsProposedEvents =
     transactionsProposedEvents.filter(
-      event => event.args?.explanation === explanation
+      event => event.args?.explanation === toUtf8Bytes(explanation)
     );
 
   console.log('transactions proposed:', thisProposalTransactionsProposedEvents);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -133,9 +133,9 @@ export const getModuleDetailsUma = async (
     };
   }
   // Check for active proposals
-  const proposalHashTimestamp = await moduleContract.proposalHashes(
-    proposalHash
-  );
+  const proposalHashTimestamp = await moduleContract
+    .proposalHashes(proposalHash)
+    .then(value => BigNumber.from(value));
   console.log('proposal hash timestamp:', proposalHashTimestamp);
 
   const activeProposal =

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -191,14 +191,16 @@ export const getModuleDetailsUma = async (
       );
     });
 
-  console.log(thisModuleTransactionsProposedEvents);
+  console.log(
+    'transactions proposed events:',
+    thisModuleTransactionsProposedEvents
+  );
 
   const executionEvents = await moduleContract.queryFilter(
-    moduleContract.filters.ProposalExecuted(
-      proposalHash /*,
-      thisModuleTransactionsProposedEvents[0].proposalTime*/
-    )
+    moduleContract.filters.ProposalExecuted(proposalHash)
   );
+
+  //thisModuleTransactionsProposedEvents[0].proposalTime
 
   const proposalExecuted = executionEvents.length > 0;
 

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -8,7 +8,7 @@ import { useWeb3 } from '@/composables';
 import { keccak256 } from '@ethersproject/keccak256';
 import { pack } from '@ethersproject/solidity';
 import { defaultAbiCoder } from '@ethersproject/abi';
-import { toUtf8Bytes } from '@ethersproject/strings';
+import { toUtf8Bytes, toUtf8String } from '@ethersproject/strings';
 
 const getBondDetails = async (
   provider: StaticJsonRpcProvider,
@@ -190,7 +190,7 @@ export const getModuleDetailsUma = async (
 
   const thisProposalTransactionsProposedEvents =
     transactionsProposedEvents.filter(
-      event => event.args?.explanation === toUtf8Bytes(explanation)
+      event => toUtf8String(event.args?.explanation) === explanation
     );
 
   console.log('explanation:', explanation);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -180,22 +180,6 @@ export const getModuleDetailsUma = async (
     })
   );
 
-  // Check for execution events matching the Snapshot proposal hash.
-  // const thisModuleTransactionsProposedEvents = await moduleContract
-  //   .queryFilter(moduleContract.filters.TransactionsProposed())
-  //   .then(result => {
-  //     return result.filter(
-  //       event =>
-  //         event.args?.explanation === toUtf8Bytes(explanation) &&
-  //         event.args?.proposalHash === proposalHash
-  //     );
-  //   });
-
-  // console.log(
-  //   'transactions proposed events:',
-  //   thisModuleTransactionsProposedEvents
-  // );
-
   const transactionsProposedEvents = await moduleContract.queryFilter(
     moduleContract.filters.TransactionsProposed()
   );
@@ -206,7 +190,11 @@ export const getModuleDetailsUma = async (
     );
 
   console.log('explanation:', explanation);
-  console.log('transactions proposed:', thisProposalTransactionsProposedEvents);
+  console.log('transactions proposed:', transactionsProposedEvents);
+  console.log(
+    'transactions proposed for this proposal:',
+    thisProposalTransactionsProposedEvents
+  );
 
   const executionEvents = await moduleContract.queryFilter(
     moduleContract.filters.ProposalExecuted(proposalHash)

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -144,8 +144,7 @@ export const getModuleDetailsUma = async (
   );
 
   const thisModuleProposalEvents = proposalEvents.filter(
-    event => event.args?.ancillaryData === ancillaryData /*&&
-      event.args?.timestamp == currentProposalHashTimestamp*/
+    event => event.args?.ancillaryData === ancillaryData
   );
 
   // Get the full proposal events (with state and disputer).
@@ -183,7 +182,10 @@ export const getModuleDetailsUma = async (
 
   // Check for execution events matching the Snapshot proposal hash.
   const executionEvents = await moduleContract.queryFilter(
-    moduleContract.filters.ProposalExecuted(proposalHash)
+    moduleContract.filters.ProposalExecuted(
+      proposalHash,
+      thisModuleFullProposalEvents[0].proposalTime
+    )
   );
 
   const proposalExecuted = executionEvents.length > 0;

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -186,7 +186,9 @@ export const getModuleDetailsUma = async (
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
 
-  const proposalExecuted = false;
+  const proposalExecuted = executionEvents.length > 0;
+
+  // const proposalExecuted = false;
 
   // if (thisModuleFullProposalEvents) {
   //   // Check if execution event matches this specific Snapshot proposal's IPFS CID.

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -136,6 +136,8 @@ export const getModuleDetailsUma = async (
   const proposalHashTimestamp = await moduleContract.proposalHashes(
     proposalHash
   );
+  console.log('proposal hash timestamp:', proposalHashTimestamp);
+
   const activeProposal =
     proposalHashTimestamp != '0x0000000000000000000000000000000000000000';
   console.log('active proposal?', activeProposal);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -190,7 +190,7 @@ export const getModuleDetailsUma = async (
 
   const thisProposalTransactionsProposedEvents =
     transactionsProposedEvents.filter(
-      event => event.args?.explanation === toUtf8Bytes(explanation)
+      event => event.args?.explanation === explanation
     );
 
   console.log('explanation:', explanation);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -136,7 +136,7 @@ export const getModuleDetailsUma = async (
   const proposalHashTimestamp = await moduleContract.proposalHashes(
     proposalHash
   );
-  console.log('proposal hash timestamp:', proposalHashTimestamp);
+  console.log('proposal hash timestamp:', proposalHashTimestamp.toNumber);
 
   const activeProposal = proposalHashTimestamp > 0;
   console.log('active proposal?', activeProposal);
@@ -158,7 +158,7 @@ export const getModuleDetailsUma = async (
   const thisModuleProposalEvents = proposalEvents.filter(
     event =>
       event.args?.ancillaryData === ancillaryData &&
-      event.args?.timestamp === proposalHashTimestamp
+      event.args?.timestamp.toNumber === proposalHashTimestamp.toNumber
   );
 
   console.log('this module proposal events:', thisModuleProposalEvents);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -133,15 +133,12 @@ export const getModuleDetailsUma = async (
     };
   }
   // Check for active proposals
-  const proposalHashTimestamp = await moduleContract.proposalHashes(
-    proposalHash
+  const proposalHashTimestamp = BigNumber.from(
+    await moduleContract.proposalHashes(proposalHash)
   );
-  console.log(
-    'proposal hash timestamp:',
-    BigNumber.from(proposalHashTimestamp)
-  );
+  console.log('proposal hash timestamp:', proposalHashTimestamp);
 
-  const activeProposal = BigNumber.from(proposalHashTimestamp).isZero;
+  const activeProposal = proposalHashTimestamp.isZero;
   console.log('active proposal?', activeProposal);
 
   // Search for requests with matching ancillary data

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -198,16 +198,9 @@ export const getModuleDetailsUma = async (
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
 
-  const proposalTimes: any = [];
-  const executionTimes: any = [];
+  const proposalTimes = thisProposalTransactionsProposedEvents.map(tx => tx.args?.proposalTime.toString());
 
-  thisProposalTransactionsProposedEvents.forEach(tx =>
-    proposalTimes.push(tx.args?.proposalTime.toString())
-  );
-
-  executionEvents.forEach(tx =>
-    executionTimes.push(tx.args?.proposalTime.toString())
-  );
+  const executionTimes = executionEvents.map(tx => tx.args?.proposalTime.toString());
 
   const proposalExecuted = proposalTimes.some(time =>
     executionTimes.includes(time)

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -136,10 +136,7 @@ export const getModuleDetailsUma = async (
   const proposalHashTimestamp = await moduleContract.proposalHashes(
     proposalHash
   );
-  console.log('proposal hash timestamp:', proposalHashTimestamp);
-
   const activeProposal = proposalHashTimestamp.gt(0);
-  console.log('active proposal?', activeProposal);
 
   // Search for requests with matching ancillary data
   const oracleContract = new Contract(
@@ -153,15 +150,11 @@ export const getModuleDetailsUma = async (
     oracleContract.filters.ProposePrice(moduleAddress)
   );
 
-  console.log('proposal events:', proposalEvents);
-
   const thisModuleProposalEvent = proposalEvents.filter(
     event =>
       event.args?.ancillaryData === ancillaryData &&
       event.args?.timestamp.toString() === proposalHashTimestamp.toString()
   );
-
-  console.log('this module proposal event:', thisModuleProposalEvent);
 
   // Get the full proposal events (with state and disputer).
   const thisModuleFullProposalEvent = await Promise.all(
@@ -196,6 +189,7 @@ export const getModuleDetailsUma = async (
     })
   );
 
+  // Check if this specific proposal has already been executed.
   const transactionsProposedEvents = await moduleContract.queryFilter(
     moduleContract.filters.TransactionsProposed()
   );
@@ -205,37 +199,24 @@ export const getModuleDetailsUma = async (
       event => toUtf8String(event.args?.explanation) === explanation
     );
 
-  console.log('explanation:', explanation);
-  console.log('explanation to bytes:', toUtf8Bytes(explanation));
-  console.log('transactions proposed:', transactionsProposedEvents);
-  console.log(
-    'transactions proposed for this proposal:',
-    thisProposalTransactionsProposedEvents
-  );
-
   const executionEvents = await moduleContract.queryFilter(
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
 
-  console.log('execution events matching proposal hash:', executionEvents);
-
   const proposalTimes: any = [];
   const executionTimes: any = [];
+
   thisProposalTransactionsProposedEvents.forEach(tx =>
     proposalTimes.push(tx.args?.proposalTime.toString())
   );
+
   executionEvents.forEach(tx =>
     executionTimes.push(tx.args?.proposalTime.toString())
   );
 
-  console.log('proposal times:', proposalTimes);
-  console.log('execution times:', executionTimes);
-
   const proposalExecuted = proposalTimes.some(time =>
     executionTimes.includes(time)
   );
-
-  console.log('proposal executed?:', proposalExecuted);
 
   return {
     dao: moduleDetails[0][0],

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -202,7 +202,7 @@ export const getModuleDetailsUma = async (
 
   const thisProposalTransactionsProposedEvents =
     transactionsProposedEvents.filter(
-      event => event.args?.explanation === toUtf8Bytes(explanation)
+      event => event.args?.explanation === explanation
     );
 
   console.log('explanation:', explanation);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -222,10 +222,10 @@ export const getModuleDetailsUma = async (
   const proposalTimes: any = [];
   const executionTimes: any = [];
   thisProposalTransactionsProposedEvents.forEach(tx =>
-    proposalTimes.push(tx.args?.proposalTime.toString)
+    proposalTimes.push(tx.args?.proposalTime.toString())
   );
   executionEvents.forEach(tx =>
-    executionTimes.push(tx.args?.proposalTime.toString)
+    executionTimes.push(tx.args?.proposalTime.toString())
   );
 
   console.log('proposal times:', proposalTimes);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -190,7 +190,7 @@ export const getModuleDetailsUma = async (
 
   const thisProposalTransactionsProposedEvents =
     transactionsProposedEvents.filter(
-      event => event.args?.explanation === explanation
+      event => event.args?.explanation === toUtf8Bytes(explanation)
     );
 
   console.log('explanation:', explanation);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -92,7 +92,6 @@ export const getModuleDetailsUma = async (
 
   // Create ancillary data for proposal hash
   let ancillaryData = '';
-  let currentProposalHashTimestamp = 0;
   let proposalHash;
   if (transactions !== undefined) {
     proposalHash = keccak256(
@@ -109,9 +108,6 @@ export const getModuleDetailsUma = async (
         pack(['string', 'string'], ['proposalHash', ':']),
         toUtf8Bytes(proposalHash.replace('0x', ''))
       ]
-    );
-    currentProposalHashTimestamp = await moduleContract.proposalHashes(
-      proposalHash
     );
   } else {
     return {
@@ -182,8 +178,7 @@ export const getModuleDetailsUma = async (
             isDisputed: isDisputed,
             isSettled: result.settled,
             resolvedPrice: result.resolvedPrice,
-            proposalHash: proposalHash,
-            proposalTime: result.timestamp
+            proposalHash: proposalHash
           };
         });
     })

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -149,14 +149,6 @@ export const getModuleDetailsUma = async (
       event.args?.timestamp == currentProposalHashTimestamp
   );
 
-  const transactionsProposedEvents = await moduleContract
-    .queryFilter(moduleContract.filters.TransactionsProposed())
-    .then(result => {
-      return result.filter(
-        event => event.args?.explanation === toUtf8Bytes(explanation)
-      );
-    });
-
   // Get the full proposal event (with state and disputer).
   const proposalEvent = await Promise.all(
     thisModuleCurrentProposalEvent.map(event => {
@@ -189,9 +181,19 @@ export const getModuleDetailsUma = async (
     })
   );
 
+  // Check for execution events matching the Snapshot proposal hash.
   const executionEvents = await moduleContract.queryFilter(
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
+
+  // Check if execution event matches this specific Snapshot proposal's IPFS CID.
+  const transactionsProposedEvents = await moduleContract
+    .queryFilter(moduleContract.filters.TransactionsProposed())
+    .then(result => {
+      return result.filter(
+        event => event.args?.explanation === toUtf8Bytes(explanation)
+      );
+    });
 
   const proposalExecuted =
     executionEvents.length > 0 && transactionsProposedEvents.length > 0;

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -222,9 +222,11 @@ export const getModuleDetailsUma = async (
   const proposalTimes: any = [];
   const executionTimes: any = [];
   thisProposalTransactionsProposedEvents.forEach(tx =>
-    proposalTimes.push(tx.args?.proposalTime)
+    proposalTimes.push(tx.args?.proposalTime.toString)
   );
-  executionEvents.forEach(tx => executionTimes.push(tx.args?.proposalTime));
+  executionEvents.forEach(tx =>
+    executionTimes.push(tx.args?.proposalTime.toString)
+  );
 
   console.log('proposal times:', proposalTimes);
   console.log('execution times:', executionTimes);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -230,6 +230,8 @@ export const getModuleDetailsUma = async (
     executionTimes.includes(time)
   );
 
+  console.log('proposal executed?:', proposalExecuted);
+
   return {
     dao: moduleDetails[0][0],
     oracle: moduleDetails[1][0],

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -244,7 +244,7 @@ export const getModuleDetailsUma = async (
     needsBondApproval: needsApproval,
     noTransactions: false,
     activeProposal: activeProposal,
-    proposalEvent: thisModuleFullProposalEvent,
+    proposalEvent: thisModuleFullProposalEvent[0],
     proposalExecuted: proposalExecuted
   };
 };

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -194,6 +194,7 @@ export const getModuleDetailsUma = async (
     );
 
   console.log('explanation:', explanation);
+  console.log('explanation to bytes:', toUtf8Bytes(explanation));
   console.log('transactions proposed:', transactionsProposedEvents);
   console.log(
     'transactions proposed for this proposal:',

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -136,7 +136,7 @@ export const getModuleDetailsUma = async (
   const proposalHashTimestamp = await moduleContract.proposalHashes(
     proposalHash
   );
-  console.log('proposal hash timestamp:', proposalHashTimestamp.toNumber);
+  console.log('proposal hash timestamp:', proposalHashTimestamp);
 
   const activeProposal = proposalHashTimestamp.gt(0);
   console.log('active proposal?', activeProposal);
@@ -158,7 +158,7 @@ export const getModuleDetailsUma = async (
   const thisModuleProposalEvents = proposalEvents.filter(
     event =>
       event.args?.ancillaryData === ancillaryData &&
-      event.args?.timestamp === proposalHashTimestamp
+      event.args?.timestamp == proposalHashTimestamp
   );
 
   console.log('this module proposal events:', thisModuleProposalEvents);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -202,7 +202,7 @@ export const getModuleDetailsUma = async (
 
   const thisProposalTransactionsProposedEvents =
     transactionsProposedEvents.filter(
-      event => event.args?.explanation === explanation
+      event => event.args?.explanation === toUtf8Bytes(explanation)
     );
 
   console.log('explanation:', explanation);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -143,9 +143,13 @@ export const getModuleDetailsUma = async (
     oracleContract.filters.ProposePrice(moduleAddress)
   );
 
+  console.log('proposal events:', proposalEvents);
+
   const thisModuleProposalEvents = proposalEvents.filter(
     event => event.args?.ancillaryData === ancillaryData
   );
+
+  console.log('this module proposal events:', thisModuleProposalEvents);
 
   // Get the full proposal events (with state and disputer).
   const thisModuleFullProposalEvents = await Promise.all(

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -186,24 +186,24 @@ export const getModuleDetailsUma = async (
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
 
-  let proposalExecuted = false;
+  const proposalExecuted = false;
 
-  if (thisModuleFullProposalEvents) {
-    // Check if execution event matches this specific Snapshot proposal's IPFS CID.
-    const transactionsProposedEvents = await moduleContract
-      .queryFilter(moduleContract.filters.TransactionsProposed())
-      .then(result => {
-        return result.filter(
-          event =>
-            event.args?.explanation === toUtf8Bytes(explanation) &&
-            event.args?.proposalHash === proposalHash
-        );
-      });
+  // if (thisModuleFullProposalEvents) {
+  //   // Check if execution event matches this specific Snapshot proposal's IPFS CID.
+  //   const transactionsProposedEvents = await moduleContract
+  //     .queryFilter(moduleContract.filters.TransactionsProposed())
+  //     .then(result => {
+  //       return result.filter(
+  //         event =>
+  //           event.args?.explanation === toUtf8Bytes(explanation) &&
+  //           event.args?.proposalHash === proposalHash
+  //       );
+  //     });
 
-    // Set proposal executed to true if this Snapshot proposal was executed.
-    proposalExecuted =
-      executionEvents.length > 0 && transactionsProposedEvents.length > 0;
-  }
+  //   // Set proposal executed to true if this Snapshot proposal was executed.
+  //   proposalExecuted =
+  //     executionEvents.length > 0 && transactionsProposedEvents.length > 0;
+  // }
 
   return {
     dao: moduleDetails[0][0],

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -138,7 +138,7 @@ export const getModuleDetailsUma = async (
   );
   console.log('proposal hash timestamp:', proposalHashTimestamp);
 
-  const activeProposal = proposalHashTimestamp > 0;
+  const activeProposal = proposalHashTimestamp.gt(0);
   console.log('active proposal?', activeProposal);
 
   // Search for requests with matching ancillary data

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -207,7 +207,16 @@ export const getModuleDetailsUma = async (
 
   console.log('execution events matching proposal hash:', executionEvents);
 
-  const proposalExecuted = executionEvents.length > 0;
+  const proposalTimes: any = [];
+  const executionTimes: any = [];
+  thisProposalTransactionsProposedEvents.forEach(tx =>
+    proposalTimes.push(tx.args?.proposalTime)
+  );
+  executionEvents.forEach(tx => executionTimes.push(tx.args?.proposalTime));
+
+  const proposalExecuted = proposalTimes.some(time =>
+    executionTimes.includes(time)
+  );
 
   return {
     dao: moduleDetails[0][0],

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -155,17 +155,17 @@ export const getModuleDetailsUma = async (
 
   console.log('proposal events:', proposalEvents);
 
-  const thisModuleProposalEvents = proposalEvents.filter(
+  const thisModuleProposalEvent = proposalEvents.filter(
     event =>
       event.args?.ancillaryData === ancillaryData &&
       event.args?.timestamp.toString() === proposalHashTimestamp.toString()
   );
 
-  console.log('this module proposal events:', thisModuleProposalEvents);
+  console.log('this module proposal event:', thisModuleProposalEvent);
 
   // Get the full proposal events (with state and disputer).
-  const thisModuleFullProposalEvents = await Promise.all(
-    thisModuleProposalEvents.map(event => {
+  const thisModuleFullProposalEvent = await Promise.all(
+    thisModuleProposalEvent.map(event => {
       return oracleContract
         .getRequest(
           event.args?.requester,
@@ -244,7 +244,7 @@ export const getModuleDetailsUma = async (
     needsBondApproval: needsApproval,
     noTransactions: false,
     activeProposal: activeProposal,
-    proposalEvent: thisModuleFullProposalEvents[0],
+    proposalEvent: thisModuleFullProposalEvent,
     proposalExecuted: proposalExecuted
   };
 };

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -136,7 +136,7 @@ export const getModuleDetailsUma = async (
   const proposalHashTimestamp = await moduleContract.proposalHashes(
     proposalHash
   );
-  console.log('proposal hash timestamp:', proposalHashTimestamp.toNumber);
+  console.log('proposal hash timestamp:', proposalHashTimestamp);
 
   const activeProposal = proposalHashTimestamp > 0;
   console.log('active proposal?', activeProposal);
@@ -158,7 +158,7 @@ export const getModuleDetailsUma = async (
   const thisModuleProposalEvents = proposalEvents.filter(
     event =>
       event.args?.ancillaryData === ancillaryData &&
-      event.args?.timestamp.toNumber === proposalHashTimestamp.toNumber
+      event.args?.timestamp === proposalHashTimestamp
   );
 
   console.log('this module proposal events:', thisModuleProposalEvents);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -181,26 +181,24 @@ export const getModuleDetailsUma = async (
   );
 
   // Check for execution events matching the Snapshot proposal hash.
-  const thisModuleTransactionsProposedEvents = await moduleContract
-    .queryFilter(moduleContract.filters.TransactionsProposed())
-    .then(result => {
-      return result.filter(
-        event =>
-          event.args?.explanation === toUtf8Bytes(explanation) &&
-          event.args?.proposalHash === proposalHash
-      );
-    });
+  // const thisModuleTransactionsProposedEvents = await moduleContract
+  //   .queryFilter(moduleContract.filters.TransactionsProposed())
+  //   .then(result => {
+  //     return result.filter(
+  //       event =>
+  //         event.args?.explanation === toUtf8Bytes(explanation) &&
+  //         event.args?.proposalHash === proposalHash
+  //     );
+  //   });
 
-  console.log(
-    'transactions proposed events:',
-    thisModuleTransactionsProposedEvents
-  );
+  // console.log(
+  //   'transactions proposed events:',
+  //   thisModuleTransactionsProposedEvents
+  // );
 
   const executionEvents = await moduleContract.queryFilter(
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
-
-  //thisModuleTransactionsProposedEvents[0].proposalTime
 
   const proposalExecuted = executionEvents.length > 0;
 

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -66,6 +66,7 @@ export const getModuleDetailsUma = async (
   userBalance: BigNumber;
   needsBondApproval: boolean;
   noTransactions: boolean;
+  activeProposal: boolean;
   proposalEvent: any;
   proposalExecuted: boolean;
 }> => {
@@ -126,10 +127,18 @@ export const getModuleDetailsUma = async (
       userBalance: bondDetails.currentUserBalance,
       needsBondApproval: needsApproval,
       noTransactions: true,
+      activeProposal: false,
       proposalEvent: {},
       proposalExecuted: false
     };
   }
+  // Check for active proposals
+  const proposalHashTimestamp = await moduleContract.proposalHashes(
+    proposalHash
+  );
+  const activeProposal =
+    proposalHashTimestamp != '0x0000000000000000000000000000000000000000';
+  console.log('active proposal?', activeProposal);
 
   // Search for requests with matching ancillary data
   const oracleContract = new Contract(
@@ -231,6 +240,7 @@ export const getModuleDetailsUma = async (
     userBalance: bondDetails.currentUserBalance,
     needsBondApproval: needsApproval,
     noTransactions: false,
+    activeProposal: activeProposal,
     proposalEvent: thisModuleFullProposalEvents[0],
     proposalExecuted: proposalExecuted
   };

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -181,10 +181,22 @@ export const getModuleDetailsUma = async (
   );
 
   // Check for execution events matching the Snapshot proposal hash.
+  const thisModuleTransactionsProposedEvents = await moduleContract
+    .queryFilter(moduleContract.filters.TransactionsProposed())
+    .then(result => {
+      return result.filter(
+        event =>
+          event.args?.explanation === toUtf8Bytes(explanation) &&
+          event.args?.proposalHash === proposalHash
+      );
+    });
+
+  console.log(thisModuleTransactionsProposedEvents);
+
   const executionEvents = await moduleContract.queryFilter(
     moduleContract.filters.ProposalExecuted(
-      proposalHash,
-      thisModuleFullProposalEvents[0].proposalTime
+      proposalHash /*,
+      thisModuleTransactionsProposedEvents[0].proposalTime*/
     )
   );
 

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -202,9 +202,10 @@ export const getModuleDetailsUma = async (
 
   const thisProposalTransactionsProposedEvents =
     transactionsProposedEvents.filter(
-      event => event.args?.explanation === toUtf8Bytes(explanation)
+      event => event.args?.explanation === explanation
     );
 
+  console.log('explanation:', explanation);
   console.log('transactions proposed:', thisProposalTransactionsProposedEvents);
 
   const executionEvents = await moduleContract.queryFilter(

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -136,7 +136,7 @@ export const getModuleDetailsUma = async (
   const proposalHashTimestamp = await moduleContract.proposalHashes(
     proposalHash
   );
-  console.log('proposal hash timestamp:', proposalHashTimestamp);
+  console.log('proposal hash timestamp:', proposalHashTimestamp.toNumber);
 
   const activeProposal = proposalHashTimestamp.gt(0);
   console.log('active proposal?', activeProposal);

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -226,6 +226,9 @@ export const getModuleDetailsUma = async (
   );
   executionEvents.forEach(tx => executionTimes.push(tx.args?.proposalTime));
 
+  console.log('proposal times:', proposalTimes);
+  console.log('execution times:', executionTimes);
+
   const proposalExecuted = proposalTimes.some(time =>
     executionTimes.includes(time)
   );

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -196,30 +196,22 @@ export const getModuleDetailsUma = async (
   //   thisModuleTransactionsProposedEvents
   // );
 
+  const transactionsProposedEvents = await moduleContract.queryFilter(
+    moduleContract.filters.TransactionsProposed()
+  );
+
+  const thisProposalTransactionsProposedEvents =
+    transactionsProposedEvents.filter(
+      event => event.args?.explanation === explanation
+    );
+
+  console.log('transactions proposed:', thisProposalTransactionsProposedEvents);
+
   const executionEvents = await moduleContract.queryFilter(
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
 
   const proposalExecuted = executionEvents.length > 0;
-
-  // const proposalExecuted = false;
-
-  // if (thisModuleFullProposalEvents) {
-  //   // Check if execution event matches this specific Snapshot proposal's IPFS CID.
-  //   const transactionsProposedEvents = await moduleContract
-  //     .queryFilter(moduleContract.filters.TransactionsProposed())
-  //     .then(result => {
-  //       return result.filter(
-  //         event =>
-  //           event.args?.explanation === toUtf8Bytes(explanation) &&
-  //           event.args?.proposalHash === proposalHash
-  //       );
-  //     });
-
-  //   // Set proposal executed to true if this Snapshot proposal was executed.
-  //   proposalExecuted =
-  //     executionEvents.length > 0 && transactionsProposedEvents.length > 0;
-  // }
 
   return {
     dao: moduleDetails[0][0],

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -183,26 +183,32 @@ export const getModuleDetailsUma = async (
   );
 
   // Check for execution events matching the Snapshot proposal hash.
-  const executionEvents = await moduleContract.queryFilter(
-    moduleContract.filters.ProposalExecuted(
-      proposalHash,
-      proposalEvent[0].proposalTime
-    )
-  );
+  let executionEvents;
+  let proposalExecuted = false;
 
-  // Check if execution event matches this specific Snapshot proposal's IPFS CID.
-  const transactionsProposedEvents = await moduleContract
-    .queryFilter(moduleContract.filters.TransactionsProposed())
-    .then(result => {
-      return result.filter(
-        event =>
-          event.args?.explanation === toUtf8Bytes(explanation) &&
-          event.args?.proposalHash === proposalHash
-      );
-    });
+  if (proposalEvent[0]) {
+    executionEvents = await moduleContract.queryFilter(
+      moduleContract.filters.ProposalExecuted(
+        proposalHash,
+        proposalEvent[0].proposalTime
+      )
+    );
 
-  const proposalExecuted =
-    executionEvents.length > 0 && transactionsProposedEvents.length > 0;
+    // Check if execution event matches this specific Snapshot proposal's IPFS CID.
+    const transactionsProposedEvents = await moduleContract
+      .queryFilter(moduleContract.filters.TransactionsProposed())
+      .then(result => {
+        return result.filter(
+          event =>
+            event.args?.explanation === toUtf8Bytes(explanation) &&
+            event.args?.proposalHash === proposalHash
+        );
+      });
+
+    // Set proposal executed to true if this Snapshot proposal was executed.
+    proposalExecuted =
+      executionEvents.length > 0 && transactionsProposedEvents.length > 0;
+  }
 
   return {
     dao: moduleDetails[0][0],

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -241,7 +241,7 @@ export const getModuleDetailsUma = async (
     userBalance: bondDetails.currentUserBalance,
     needsBondApproval: needsApproval,
     noTransactions: false,
-    activeProposal: activeProposal,
+    activeProposal: activeProposal(),
     proposalEvent: thisModuleFullProposalEvents[0],
     proposalExecuted: proposalExecuted
   };

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -205,6 +205,8 @@ export const getModuleDetailsUma = async (
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
 
+  console.log('execution events matching proposal hash:', executionEvents);
+
   const proposalExecuted = executionEvents.length > 0;
 
   return {

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -183,28 +183,28 @@ export const getModuleDetailsUma = async (
   );
 
   // Check for execution events matching the Snapshot proposal hash.
-  const executionEvents = await moduleContract.queryFilter(
-    moduleContract.filters.ProposalExecuted(proposalHash)
-  );
+  // const executionEvents = await moduleContract.queryFilter(
+  //   moduleContract.filters.ProposalExecuted(proposalHash)
+  // );
 
   const proposalExecuted = false;
 
-  if (thisModuleFullProposalEvents) {
-    // Check if execution event matches this specific Snapshot proposal's IPFS CID.
-    const transactionsProposedEvents = await moduleContract
-      .queryFilter(moduleContract.filters.TransactionsProposed())
-      .then(result => {
-        return result.filter(
-          event =>
-            event.args?.explanation === toUtf8Bytes(explanation) &&
-            event.args?.proposalHash === proposalHash
-        );
-      });
+  // if (thisModuleFullProposalEvents) {
+  //   // Check if execution event matches this specific Snapshot proposal's IPFS CID.
+  //   const transactionsProposedEvents = await moduleContract
+  //     .queryFilter(moduleContract.filters.TransactionsProposed())
+  //     .then(result => {
+  //       return result.filter(
+  //         event =>
+  //           event.args?.explanation === toUtf8Bytes(explanation) &&
+  //           event.args?.proposalHash === proposalHash
+  //       );
+  //     });
 
-    // Set proposal executed to true if this Snapshot proposal was executed.
-    // proposalExecuted =
-    //   executionEvents.length > 0 && transactionsProposedEvents.length > 0;
-  }
+  // Set proposal executed to true if this Snapshot proposal was executed.
+  // proposalExecuted =
+  //   executionEvents.length > 0 && transactionsProposedEvents.length > 0;
+  // }
 
   return {
     dao: moduleDetails[0][0],

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -133,12 +133,12 @@ export const getModuleDetailsUma = async (
     };
   }
   // Check for active proposals
-  const proposalHashTimestamp = BigNumber.from(
-    await moduleContract.proposalHashes(proposalHash)
+  const proposalHashTimestamp = await moduleContract.proposalHashes(
+    proposalHash
   );
   console.log('proposal hash timestamp:', proposalHashTimestamp);
 
-  const activeProposal = proposalHashTimestamp.isZero;
+  const activeProposal = proposalHashTimestamp > 0;
   console.log('active proposal?', activeProposal);
 
   // Search for requests with matching ancillary data
@@ -241,7 +241,7 @@ export const getModuleDetailsUma = async (
     userBalance: bondDetails.currentUserBalance,
     needsBondApproval: needsApproval,
     noTransactions: false,
-    activeProposal: activeProposal(),
+    activeProposal: activeProposal,
     proposalEvent: thisModuleFullProposalEvents[0],
     proposalExecuted: proposalExecuted
   };


### PR DESCRIPTION
Fixes #

Changes in this PR:
- Improves state management in the UMA module
- Tracks whether a specific Snapshot proposal was executed, not just whether a proposal with matching transactions was executed
- Cleans up comments and console logs
- Uses the unique Snapshot vote IPFS CID as the `explanation` when proposing transactions to the Optimistic Governor

How to test and review this PR?
- Test end-to-end flow on Vercel preview