### PR TITLE
Fix issue with rejected proposals

### DIFF
--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -319,9 +319,7 @@ const questionState = computed(() => {
     return QuestionStates.waitingForProposal;
 
   // Proposal can be deleted if it has been rejected.
-  if (proposalEvent.isDisputed && proposalEvent.resolvedPrice == 0)
-    return QuestionStates.proposalRejected;
-
+  if (proposalEvent.isRejectable) return QuestionStates.proposalRejected;
   // If disputed, a proposal can be deleted to enable a proposal to be proposed again.
   if (proposalEvent.isDisputed) return QuestionStates.disputedButNotResolved;
 

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -76,11 +76,13 @@ export const getModuleDetailsUma = async (
     [moduleAddress, 'optimisticOracle'],
     [moduleAddress, 'rules'],
     [moduleAddress, 'bondAmount'],
-    [moduleAddress, 'liveness']
+    [moduleAddress, 'liveness'],
+    [moduleAddress, 'PROPOSAL_VALID_RESPONSE']
   ]);
   let needsApproval = false;
   const minimumBond = moduleDetails[3][0];
   const optimisticOracle = moduleDetails[1][0];
+  const validPrice = moduleDetails[5][0].toString();
   const bondDetails = await getBondDetails(provider, moduleAddress);
 
   if (
@@ -154,7 +156,17 @@ export const getModuleDetailsUma = async (
 
   // Get the full proposal events (with state and disputer).
   const thisModuleFullProposalEvent = await Promise.all(
-    thisModuleProposalEvent.map(event => {
+    thisModuleProposalEvent.map(async event => {
+      const settledPriceCheck = await oracleContract.callStatic
+        .settleAndGetPrice(
+          event.args?.identifier,
+          event.args?.timestamp,
+          event.args?.ancillaryData,
+          { from: event.args?.requester }
+        )
+        .then(price => price.toString())
+        .catch(() => undefined);
+
       return oracleContract
         .getRequest(
           event.args?.requester,
@@ -172,10 +184,16 @@ export const getModuleDetailsUma = async (
             Math.floor(Date.now() / 1000) >=
             Number(event.args?.expirationTimestamp);
 
+          const isRejectable =
+            settledPriceCheck !== undefined && settledPriceCheck !== validPrice
+              ? true
+              : false;
+
           return {
             expirationTimestamp: event.args?.expirationTimestamp,
             isExpired: isExpired,
             isDisputed: isDisputed,
+            isRejectable: isRejectable,
             isSettled: result.settled,
             resolvedPrice: result.resolvedPrice,
             proposalHash: proposalHash
@@ -198,9 +216,13 @@ export const getModuleDetailsUma = async (
     moduleContract.filters.ProposalExecuted(proposalHash)
   );
 
-  const proposalTimes = thisProposalTransactionsProposedEvents.map(tx => tx.args?.proposalTime.toString());
+  const proposalTimes = thisProposalTransactionsProposedEvents.map(tx =>
+    tx.args?.proposalTime.toString()
+  );
 
-  const executionTimes = executionEvents.map(tx => tx.args?.proposalTime.toString());
+  const executionTimes = executionEvents.map(tx =>
+    tx.args?.proposalTime.toString()
+  );
 
   const proposalExecuted = proposalTimes.some(time =>
     executionTimes.includes(time)


### PR DESCRIPTION
Signed-off-by: Alex Gaines <againes@umaproject.org>

Currently if a proposal is disputed the UI gives the option for the user to delete a rejected proposal because `proposalEvent.resolvedPrice` is being returned as 0. The transaction also fails if you try to execute. 

This PR makes an update to get the `PROPOSAL_VALID_RESPONSE` from the optimistic governor contract and compare the value against `settleAndGetPrice` if a value is returned.

Let me know if you see an easier way of implementing this change or I am missing something. For testing, I found the easiest way to check the state changes was hardcoding the `validPrice` value to simulate different values being returned.