### PR TITLE
Add tooltip explanations to UMA module

### DIFF
--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -649,7 +649,11 @@
       "confirmVoteResults": "Click to confirm the proposal passed",
       "executeTxsUma": "Execute transaction batch",
       "deleteDisputedProposal": "Delete disputed proposal",
-      "deleteRejectedProposal": "Delete rejected proposal"
+      "deleteRejectedProposal": "Delete rejected proposal",
+      "confirmVoteResultsToolTip": "Make sure this proposal was approved by this Snapshot vote before proposing on-chain. If the Snapshot vote rejected the proposal, the on-chain proposal will be rejected as well and you will lose your bond.",
+      "approveBondToolTip": "On-chain proposals require a bond from the proposer. This will approve tokens from your wallet to be posted as a bond. If you make an invalid proposal, it will be disputed and you will lose your bond. If the proposal is valid, your bond will be returned when the transactions are executed.",
+      "requestToolTip": "This will propose the transactions from this Snapshot vote on-chain. After a challenge window, if the proposal is valid, the transactions can be executed and your bond will be returned.",
+      "executeToolTip": "This will execute the transactions from this proposal and return the proposer's bond."
     }
   },
   "poap": {

--- a/src/plugins/safeSnap/components/HandleOutcomeUma.vue
+++ b/src/plugins/safeSnap/components/HandleOutcomeUma.vue
@@ -358,14 +358,20 @@ onMounted(async () => {
   <div v-if="connectedToRightChain || usingMetaMask">
     <div
       v-if="questionState === questionStates.waitingForVoteConfirmation"
-      class="my-4"
+      class="my-4 inline-block"
     >
-      <BaseButton
-        :loading="actionInProgress === 'confirm-vote-results'"
-        @click="confirmVoteResults"
-      >
-        {{ $t('safeSnap.labels.confirmVoteResults') }}
-      </BaseButton>
+      <BaseContainer class="flex items-center">
+        <BaseButton
+          :loading="actionInProgress === 'confirm-vote-results'"
+          @click="confirmVoteResults"
+        >
+          {{ $t('safeSnap.labels.confirmVoteResults') }}
+        </BaseButton>
+        <IconInformationTooltip
+          :information="$t('safeSnap.labels.confirmVoteResultsToolTip')"
+          class="ml-2"
+        />
+      </BaseContainer>
     </div>
 
     <div v-if="questionState === questionStates.noTransactions" class="my-4">
@@ -377,29 +383,40 @@ onMounted(async () => {
         questionState === questionStates.waitingForProposal &&
         questionDetails.needsBondApproval === true
       "
-      class="my-4"
+      class="my-4 inline-block"
     >
-      <BaseButton
-        :loading="actionInProgress === 'approve-bond'"
-        @click="approveBond"
-      >
-        {{ $t('safeSnap.labels.approveBond') }}
-      </BaseButton>
+      <BaseContainer class="flex items-center">
+        <BaseButton
+          :loading="actionInProgress === 'approve-bond'"
+          @click="approveBond"
+        >
+          {{ $t('safeSnap.labels.approveBond') }}
+        </BaseButton>
+        <IconInformationTooltip
+          :information="$t('safeSnap.labels.approveBondToolTip')"
+          class="ml-2"
+        />
+      </BaseContainer>
     </div>
-
     <div
       v-if="
         questionState === questionStates.waitingForProposal &&
         questionDetails.needsBondApproval === false
       "
-      class="my-4"
+      class="my-4 inline-block"
     >
-      <BaseButton
-        :loading="actionInProgress === 'submit-proposal'"
-        @click="submitProposal"
-      >
-        {{ $t('safeSnap.labels.request') }}
-      </BaseButton>
+      <BaseContainer class="flex items-center">
+        <BaseButton
+          :loading="actionInProgress === 'submit-proposal'"
+          @click="submitProposal"
+        >
+          {{ $t('safeSnap.labels.request') }}
+        </BaseButton>
+        <IconInformationTooltip
+          :information="$t('safeSnap.labels.requestToolTip')"
+          class="ml-2"
+        />
+      </BaseContainer>
     </div>
 
     <div
@@ -435,18 +452,27 @@ onMounted(async () => {
       </BaseButton>
     </div>
 
-    <div v-if="questionState === questionStates.proposalApproved" class="my-4">
-      <BaseButton
-        :loading="action2InProgress === 'execute-proposal'"
-        @click="executeProposal"
-      >
-        {{
-          $t('safeSnap.labels.executeTxsUma', [
-            questionDetails.nextTxIndex + 1,
-            batches.length
-          ])
-        }}
-      </BaseButton>
+    <div
+      v-if="questionState === questionStates.proposalApproved"
+      class="my-4 inline-block"
+    >
+      <BaseContainer class="flex items-center">
+        <BaseButton
+          :loading="action2InProgress === 'execute-proposal'"
+          @click="executeProposal"
+        >
+          {{
+            $t('safeSnap.labels.executeTxsUma', [
+              questionDetails.nextTxIndex + 1,
+              batches.length
+            ])
+          }}
+        </BaseButton>
+        <IconInformationTooltip
+          :information="$t('safeSnap.labels.executeToolTip')"
+          class="ml-2"
+        />
+      </BaseContainer>
     </div>
   </div>
   <div


### PR DESCRIPTION
Signed-off-by: Alex Gaines <againes@umaproject.org>

Based on UX feedback, this PR includes tooltips to better explain to users what is happening during:
- When confirming vote results
- Approving the bond value
- Proposing transactions
- Executing transactions

I borrowed styling from other Snapshot components, however, if there is a better way to implement the changes let me know!
