### PR TITLE
fix: remove proposal rejected flow

### DIFF
--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -649,7 +649,6 @@
       "confirmVoteResults": "Click to confirm the proposal passed",
       "executeTxsUma": "Execute transaction batch",
       "deleteDisputedProposal": "Delete disputed proposal",
-      "deleteRejectedProposal": "Delete rejected proposal",
       "confirmVoteResultsToolTip": "Make sure this proposal was approved by this Snapshot vote before proposing on-chain. If the Snapshot vote rejected the proposal, the on-chain proposal will be rejected as well and you will lose your bond.",
       "approveBondToolTip": "On-chain proposals require a bond from the proposer. This will approve tokens from your wallet to be posted as a bond. If you make an invalid proposal, it will be disputed and you will lose your bond. If the proposal is valid, your bond will be returned when the transactions are executed.",
       "requestToolTip": "This will propose the transactions from this Snapshot vote on-chain. After a challenge window, if the proposal is valid, the transactions can be executed and your bond will be returned.",

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -221,23 +221,6 @@ export default class Plugin {
     console.log('[DAO module] deleted disputed proposal:', receipt);
   }
 
-  async *deleteRejectedProposal(
-    web3: any,
-    moduleAddress: string,
-    transactionHash: any
-  ) {
-    const tx = await sendTransaction(
-      web3,
-      moduleAddress,
-      UMA_MODULE_ABI,
-      'deleteRejectedProposal',
-      [transactionHash]
-    );
-    yield;
-    const receipt = await tx.wait();
-    console.log('[DAO module] deleted rejected proposal:', receipt);
-  }
-
   async getModuleDetailsUma(
     network: string,
     moduleAddress: string,

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -184,17 +184,10 @@ export const getModuleDetailsUma = async (
             Math.floor(Date.now() / 1000) >=
             Number(event.args?.expirationTimestamp);
 
-          const isRejected =
-            settledPriceResponse !== undefined &&
-            settledPriceResponse !== validResponse
-              ? true
-              : false;
-
           return {
             expirationTimestamp: event.args?.expirationTimestamp,
             isExpired: isExpired,
             isDisputed: isDisputed,
-            isRejectable: isRejected,
             isSettled: result.settled,
             resolvedPrice: result.resolvedPrice,
             proposalHash: proposalHash

--- a/src/plugins/safeSnap/utils/umaModule.ts
+++ b/src/plugins/safeSnap/utils/umaModule.ts
@@ -157,16 +157,6 @@ export const getModuleDetailsUma = async (
   // Get the full proposal events (with state and disputer).
   const thisModuleFullProposalEvent = await Promise.all(
     thisModuleProposalEvent.map(async event => {
-      const settledPriceResponse = await oracleContract.callStatic
-        .settleAndGetPrice(
-          event.args?.identifier,
-          event.args?.timestamp,
-          event.args?.ancillaryData,
-          { from: event.args?.requester }
-        )
-        .then(price => price.toString())
-        .catch(() => undefined);
-
       return oracleContract
         .getRequest(
           event.args?.requester,
@@ -189,7 +179,6 @@ export const getModuleDetailsUma = async (
             isExpired: isExpired,
             isDisputed: isDisputed,
             isSettled: result.settled,
-            resolvedPrice: result.resolvedPrice,
             proposalHash: proposalHash
           };
         });


### PR DESCRIPTION
Signed-off-by: John Shutt <pemulis@users.noreply.github.com>

Fixes #

Changes in this PR:
We realized that there is no need for a flow to delete a rejected proposal. Since all rejected proposals are also disputed proposals, we only need to present a flow to delete a disputed proposal. This PR deletes all of the code related to that unnecessary flow.

How to test and review this PR?
Re-test the other flows.