### PR TITLE
fix: spacing changes on outcomes page for osnap plugin

### DIFF
--- a/src/plugins/oSnap/components/HandleOutcome/steps/CanProposeToOG.vue
+++ b/src/plugins/oSnap/components/HandleOutcome/steps/CanProposeToOG.vue
@@ -25,7 +25,7 @@ const hasReachedQuorum = computed(() => props.scoresTotal >= props.quorum);
 </script>
 
 <template>
-  <div class="pl-3 pr-3">
+  <div class="!mt-2">
     <p>
       Make sure this proposal was approved by this Snapshot vote before
       asserting on-chain. If the Snapshot vote rejected the proposal, the
@@ -64,7 +64,7 @@ const hasReachedQuorum = computed(() => props.scoresTotal >= props.quorum);
     <BaseButton
       :disabled="!hasReachedQuorum || !hasSufficientBalance"
       @click="emit('approveBond')"
-      class="mr-2 w-full"
+      class="mr-2 mt-4 w-full"
     >
       Approve bond
     </BaseButton>


### PR DESCRIPTION
Fixes #

<img width="684" alt="Screenshot 2023-11-20 at 15 10 16" src="https://github.com/UMAprotocol/snapshot/assets/51655063/43fc9678-e0c6-4699-b1ed-6e68b7dac425">


Changes in this PR:

Only minor cosmetic changes regarding spacing issues pointed out in this [comment](https://github.com/snapshot-labs/snapshot/pull/4312#issuecomment-1799473097)

How to test and review this PR?
