### PR TITLE
reset to snapshot's standard 42px height

### DIFF
--- a/src/components/SettingsTreasuryActivateOsnapButton.vue
+++ b/src/components/SettingsTreasuryActivateOsnapButton.vue
@@ -1,24 +1,58 @@
 <script setup lang="ts">
+const { theme } = useSkin();
+
 defineProps<{
   isOsnapEnabled: boolean;
 }>();
+
+// handling some theming here locally so as not to interfere with the global style.scss file
+const activeStyles = computed(() => {
+  return theme.value === 'light'
+    ? {
+        div: 'bg-[hsla(122,100%,45%,0.13)] text-[hsla(122,100%,21%,1)]',
+        span: 'bg-[hsla(122,100%,45%,1)]'
+      }
+    : {
+        div: 'bg-[hsla(122,100%,45%,0.13)] text-[hsla(122,100%,45%,1)]',
+        span: 'bg-[hsla(122,100%,45%,1)]'
+      };
+});
+
+const inactiveStyles = computed(() => {
+  return theme.value === 'light'
+    ? {
+        div: 'bg-[hsla(0,0%,0%,1)] text-skin-bg',
+        span: 'bg-skin-bg opacity-30'
+      }
+    : {
+        div: 'bg-[hsla(0,0%,100%,1)] text-skin-bg',
+        span: 'bg-skin-bg opacity-30'
+      };
+});
 </script>
 
 <template>
   <button
     v-if="isOsnapEnabled"
-    class="flex items-center gap-2 rounded-full bg-[hsla(122,100%,45%,0.13)] px-3 py-2 text-[hsl(122,100%,21%)]"
+    :class="[
+      'flex items-center gap-2 rounded-full px-3 py-2',
+      activeStyles.div
+    ]"
   >
     <span
-      class="block h-[6px] w-[6px] rounded-full bg-[hsl(122,100%,45%)]"
-    ></span
-    >oSnap activated
+      :class="['block h-[6px] w-[6px] rounded-full', activeStyles.span]"
+    />oSnap activated
   </button>
   <button
     v-else
-    class="flex items-center gap-2 rounded-full bg-black px-3 py-2 text-white"
+    :class="[
+      'flex items-center gap-2 rounded-full px-3 py-2',
+      inactiveStyles.div
+    ]"
   >
-    <span class="block h-[6px] w-[6px] rounded-full bg-white/30"></span>
+    <span
+      :class="['block h-[6px] w-[6px] rounded-full', inactiveStyles.span]"
+    />
     Activate oSnap
   </button>
 </template>

--- a/src/components/SettingsTreasuryActivateOsnapButton.vue
+++ b/src/components/SettingsTreasuryActivateOsnapButton.vue
@@ -1,58 +1,24 @@
 <script setup lang="ts">
-const { theme } = useSkin();
-
 defineProps<{
   isOsnapEnabled: boolean;
 }>();
-
-// handling some theming here locally so as not to interfere with the global style.scss file
-const activeStyles = computed(() => {
-  return theme.value === 'light'
-    ? {
-        div: 'bg-[hsla(122,100%,45%,0.13)] text-[hsla(122,100%,21%,1)]',
-        span: 'bg-[hsla(122,100%,45%,1)]'
-      }
-    : {
-        div: 'bg-[hsla(122,100%,45%,0.13)] text-[hsla(122,100%,45%,1)]',
-        span: 'bg-[hsla(122,100%,45%,1)]'
-      };
-});
-
-const inactiveStyles = computed(() => {
-  return theme.value === 'light'
-    ? {
-        div: 'bg-[hsla(0,0%,0%,1)] text-skin-bg',
-        span: 'bg-skin-bg opacity-30'
-      }
-    : {
-        div: 'bg-[hsla(0,0%,100%,1)] text-skin-bg',
-        span: 'bg-skin-bg opacity-30'
-      };
-});
 </script>
 
 <template>
   <button
     v-if="isOsnapEnabled"
-    :class="[
-      'flex items-center gap-2 rounded-full px-3 py-2',
-      activeStyles.div
-    ]"
+    class="flex items-center gap-2 rounded-full bg-[hsla(122,100%,45%,0.13)] px-3 py-2 text-[hsl(122,100%,21%)]"
   >
     <span
-      :class="['block h-[6px] w-[6px] rounded-full', activeStyles.span]"
-    />oSnap activated
+      class="block h-[6px] w-[6px] rounded-full bg-[hsl(122,100%,45%)]"
+    ></span
+    >oSnap activated
   </button>
   <button
     v-else
-    :class="[
-      'flex items-center gap-2 rounded-full px-3 py-2',
-      inactiveStyles.div
-    ]"
+    class="flex items-center gap-2 rounded-full bg-black px-3 py-2 text-white"
   >
-    <span
-      :class="['block h-[6px] w-[6px] rounded-full', inactiveStyles.span]"
-    />
+    <span class="block h-[6px] w-[6px] rounded-full bg-white/30"></span>
     Activate oSnap
   </button>
 </template>

--- a/src/plugins/oSnap/components/ExternalLink.vue
+++ b/src/plugins/oSnap/components/ExternalLink.vue
@@ -16,7 +16,7 @@ defineProps<{
     :href="sanitizeUrl(link)"
     target="_blank"
     :class="[
-      'inline-flex w-full items-center gap-2 whitespace-nowrap rounded-3xl border border-skin-border bg-skin-bg px-4 font-semibold capitalize leading-[48px] hover:border-skin-text',
+      'inline-flex w-full items-center gap-2 whitespace-nowrap rounded-3xl border border-skin-border bg-skin-bg px-4 font-semibold capitalize leading-[42px] hover:border-skin-text',
       { 'pointer-events-none': disabled }
     ]"
     rel="noopener noreferrer"

--- a/src/plugins/oSnap/components/Input/ReadOnly.vue
+++ b/src/plugins/oSnap/components/Input/ReadOnly.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div
-    class="z-10 flex w-full rounded-3xl border border-skin-border bg-skin-bg px-3 text-left leading-[48px] outline-none transition-colors"
+    class="z-10 flex w-full rounded-3xl border border-skin-border bg-skin-bg px-3 text-left leading-[42px] outline-none transition-colors"
   >
     <slot />
   </div>


### PR DESCRIPTION
Fixes [#2063](https://linear.app/uma/issue/UMA-2063/match-transaction-builder-to-figma)

Changes in this PR:

@daywiss  The height of some components in our internal Figma did not match Snapshot's standard height so this is just a fix for that. Everything else in the ticket is cancelled since it would require changes to either their component library, or components outside of the plugin scope. 

How to test and review this PR?
