### PR TITLE
feat: uma 1936 add dark mode osnap buttons

### DIFF
--- a/src/components/SettingsTreasuryActivateOsnapButton.vue
+++ b/src/components/SettingsTreasuryActivateOsnapButton.vue
@@ -1,24 +1,58 @@
 <script setup lang="ts">
+const { theme } = useSkin();
+
 defineProps<{
   isOsnapEnabled: boolean;
 }>();
+
+// handling some theming here locally so as not to interfere with the global style.scss file
+const activeStyles = computed(() => {
+  return theme.value === 'light'
+    ? {
+        div: 'bg-[hsla(122,100%,45%,0.13)] text-[hsla(122,100%,21%,1)]',
+        span: 'bg-[hsla(122,100%,45%,1)]'
+      }
+    : {
+        div: 'bg-[hsla(122,100%,45%,0.13)] text-[hsla(122,100%,45%,1)]',
+        span: 'bg-[hsla(122,100%,45%,1)]'
+      };
+});
+
+const inactiveStyles = computed(() => {
+  return theme.value === 'light'
+    ? {
+        div: 'bg-[hsla(0,0%,0%,1)] text-skin-bg',
+        span: 'bg-skin-bg opacity-30'
+      }
+    : {
+        div: 'bg-[hsla(0,0%,100%,1)] text-skin-bg',
+        span: 'bg-skin-bg opacity-30'
+      };
+});
 </script>
 
 <template>
   <button
     v-if="isOsnapEnabled"
-    class="flex items-center gap-2 rounded-full bg-[hsla(122,100%,45%,0.13)] px-3 py-2 text-[hsl(122,100%,21%)]"
+    :class="[
+      'flex items-center gap-2 rounded-full px-3 py-2',
+      activeStyles.div
+    ]"
   >
     <span
-      class="block h-[6px] w-[6px] rounded-full bg-[hsl(122,100%,45%)]"
-    ></span
-    >oSnap activated
+      :class="['block h-[6px] w-[6px] rounded-full', activeStyles.span]"
+    />oSnap activated
   </button>
   <button
     v-else
-    class="flex items-center gap-2 rounded-full bg-black px-3 py-2 text-white"
+    :class="[
+      'flex items-center gap-2 rounded-full px-3 py-2',
+      inactiveStyles.div
+    ]"
   >
-    <span class="block h-[6px] w-[6px] rounded-full bg-white/30"></span>
+    <span
+      :class="['block h-[6px] w-[6px] rounded-full', inactiveStyles.span]"
+    />
     Activate oSnap
   </button>
 </template>


### PR DESCRIPTION
NOTE: The logic lives in this component so that we do not have to tamper with Snapshots global styles.scss or tailwind config files. Since we are only a plugin we don't want to overreach.

Another way to let plugin authors integrate their own styles into the app would be to define a
- tailwind presets.js file (tailwind presets that the global config can extend) and 
- a partials.scss file for our color variables. 

This might be a better approach, but for the sake of simplicity I have just gone ahead and done it this way.

Screenshots:

<img width="797" alt="Screenshot 2023-11-22 at 17 19 44" src="https://github.com/UMAprotocol/snapshot/assets/51655063/0bc8d382-f8eb-410e-9c25-bafc5a6449de">


How to test and review this PR?
