### PR TITLE
fix: change osnap activated to use snapshot's primary blue color

### DIFF
--- a/src/components/SettingsTreasuryActivateOsnapButton.vue
+++ b/src/components/SettingsTreasuryActivateOsnapButton.vue
@@ -25,9 +25,7 @@ const inactiveStyles = computed(() => {
     v-if="isOsnapEnabled"
     class="flex items-center gap-2 rounded-full px-3 py-2 bg-primary text-white"
   >
-    <span
-      :class="['block h-[6px] w-[6px] rounded-full bg-[hsla(122,100%,45%,1)]']"
-    />oSnap activated
+    <span class="block h-[6px] w-[6px] rounded-full bg-green" />oSnap activated
   </button>
   <button
     v-else

--- a/src/components/SettingsTreasuryActivateOsnapButton.vue
+++ b/src/components/SettingsTreasuryActivateOsnapButton.vue
@@ -6,17 +6,6 @@ defineProps<{
 }>();
 
 // handling some theming here locally so as not to interfere with the global style.scss file
-const activeStyles = computed(() => {
-  return theme.value === 'light'
-    ? {
-        div: 'bg-[hsla(122,100%,45%,0.13)] text-[hsla(122,100%,21%,1)]',
-        span: 'bg-[hsla(122,100%,45%,1)]'
-      }
-    : {
-        div: 'bg-[hsla(122,100%,45%,0.13)] text-[hsla(122,100%,45%,1)]',
-        span: 'bg-[hsla(122,100%,45%,1)]'
-      };
-});
 
 const inactiveStyles = computed(() => {
   return theme.value === 'light'
@@ -34,13 +23,10 @@ const inactiveStyles = computed(() => {
 <template>
   <button
     v-if="isOsnapEnabled"
-    :class="[
-      'flex items-center gap-2 rounded-full px-3 py-2',
-      activeStyles.div
-    ]"
+    class="flex items-center gap-2 rounded-full px-3 py-2 bg-primary text-white"
   >
     <span
-      :class="['block h-[6px] w-[6px] rounded-full', activeStyles.span]"
+      :class="['block h-[6px] w-[6px] rounded-full bg-[hsla(122,100%,45%,1)]']"
     />oSnap activated
   </button>
   <button


### PR DESCRIPTION
Fixes #UMA-2086

screenshots:

![Screenshot 2023-11-24 at 17 05 53](https://github.com/UMAprotocol/snapshot/assets/51655063/2226c58b-2b9a-41c1-9577-d44989dde3bf)


