### PR TITLE
fix: change osnap opt in instructions container and checkbox

### DIFF
--- a/src/components/SpaceCreateOsnap.vue
+++ b/src/components/SpaceCreateOsnap.vue
@@ -10,7 +10,9 @@ defineEmits<{
 </script>
 
 <template>
-  <div class="mb-4">
+  <div
+    class="mb-4 border-y border-skin-border bg-skin-block-bg text-base md:rounded-xl md:border p-4"
+  >
     <div v-if="legacyOsnap.enabled">
       <h6>Warning</h6>
       <p class="mb-3">


### PR DESCRIPTION
Fixes #UMA-2080

changes: 
- bordered container around instructions
- use TuneSwitch component over checkbox


screenshots:
![Screenshot 2023-11-27 at 15 58 21](https://github.com/UMAprotocol/snapshot/assets/51655063/4cdf38eb-c40d-4b71-9eb4-7754a962e383)

