### PR TITLE
remove View on IPFS link

### DIFF
--- a/src/plugins/oSnap/Proposal.vue
+++ b/src/plugins/oSnap/Proposal.vue
@@ -7,7 +7,6 @@ import HandleOutcome from './components/HandleOutcome/HandleOutcome.vue';
 import ReadOnly from './components/Input/ReadOnly.vue';
 import SafeLinkWithAvatar from './components/SafeLinkWithAvatar.vue';
 import { GnosisSafe, Transaction } from './types';
-import ExternalLink from './components/ExternalLink.vue';
 
 const keyOrder = [
   'to',
@@ -99,10 +98,7 @@ function enrichTransactionForDisplay(transaction: Transaction) {
     >
       <h2 class="text-lg">oSnap Transactions</h2>
       <div class="flex flex-col items-center gap-3 md:flex-row">
-        <SafeLinkWithAvatar class="flex-2" :safe="safe" />
-        <ExternalLink class="flex-1" v-if="ipfs" :link="ipfs">
-          View on IPFS
-        </ExternalLink>
+        <SafeLinkWithAvatar :safe="safe" />
       </div>
       <div class="divider mx-auto h-[1px] w-full bg-skin-border" />
       <div

--- a/src/plugins/oSnap/components/ExternalLink.vue
+++ b/src/plugins/oSnap/components/ExternalLink.vue
@@ -16,7 +16,7 @@ defineProps<{
     :href="sanitizeUrl(link)"
     target="_blank"
     :class="[
-      'inline-flex w-full items-center gap-2 whitespace-nowrap rounded-3xl border border-skin-border bg-skin-bg px-4 font-semibold first-letter:capitalize leading-[42px] hover:border-skin-text',
+      'inline-flex items-center gap-2 whitespace-nowrap rounded-3xl border border-skin-border bg-skin-bg px-4 font-semibold first-letter:capitalize leading-[42px] hover:border-skin-text',
       { 'pointer-events-none': disabled }
     ]"
     rel="noopener noreferrer"


### PR DESCRIPTION
Fixes #UMA-2083

Changes in this PR:
- removed redundant link to ipfs

screenshots:

![Screenshot 2023-11-27 at 17 18 46](https://github.com/UMAprotocol/snapshot/assets/51655063/010ede43-cc21-443a-9bd0-2a79f5d7a8de)
