### PR TITLE
fix: remove custom inactive osnap button styles

### DIFF
--- a/src/components/SettingsTreasuryActivateOsnapButton.vue
+++ b/src/components/SettingsTreasuryActivateOsnapButton.vue
@@ -1,42 +1,21 @@
 <script setup lang="ts">
-const { theme } = useSkin();
-
 defineProps<{
   isOsnapEnabled: boolean;
 }>();
-
-// handling some theming here locally so as not to interfere with the global style.scss file
-
-const inactiveStyles = computed(() => {
-  return theme.value === 'light'
-    ? {
-        div: 'bg-[hsla(0,0%,0%,1)] text-skin-bg',
-        span: 'bg-skin-bg opacity-30'
-      }
-    : {
-        div: 'bg-[hsla(0,0%,100%,1)] text-skin-bg',
-        span: 'bg-skin-bg opacity-30'
-      };
-});
 </script>
 
 <template>
   <button
     v-if="isOsnapEnabled"
-    class="flex items-center gap-2 rounded-full px-3 py-2 bg-primary text-white"
+    class="flex items-center gap-2 rounded-full px-3 py-2 bg-skin-primary text-white"
   >
     <span class="block h-[6px] w-[6px] rounded-full bg-green" />oSnap activated
   </button>
   <button
     v-else
-    :class="[
-      'flex items-center gap-2 rounded-full px-3 py-2',
-      inactiveStyles.div
-    ]"
+    class="bg-skin-link text-skin-bg flex items-center gap-2 rounded-full px-3 py-2"
   >
-    <span
-      :class="['block h-[6px] w-[6px] rounded-full', inactiveStyles.span]"
-    />
+    <span class="block h-[6px] w-[6px] rounded-full bg-skin-bg opacity-30" />
     Activate oSnap
   </button>
 </template>


### PR DESCRIPTION
Fixes #UMA-2092

screenshots:
ACTIVE
![Screenshot 2023-11-28 at 15 19 39](https://github.com/UMAprotocol/snapshot/assets/51655063/1020d09a-fa02-497c-ae79-c8459a8c9895)

INACTIVE

![Screenshot 2023-11-28 at 15 19 58](https://github.com/UMAprotocol/snapshot/assets/51655063/758b8bea-090d-4e1f-a25a-b59cf6322950)

inactive dark

![Screenshot 2023-11-28 at 15 20 02](https://github.com/UMAprotocol/snapshot/assets/51655063/5ccb4bab-c5aa-4170-b74a-f78e1446fa7b)

