### PR TITLE
feat: show warning if gas exceeds 500_000, refactor state

### DIFF
--- a/src/plugins/oSnap/components/TransactionBuilder/TenderlySimulation.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TenderlySimulation.vue
@@ -163,6 +163,7 @@ async function simulate() {
           >
         </div>
         <a
+          v-if="simulationState.simulationLink.public"
           target="_blank"
           class="flex items-center gap-1 text-inherit hover:underline"
           :href="simulationState.simulationLink.url"
@@ -170,6 +171,7 @@ async function simulate() {
           <span>View on Tenderly</span>
           <IHoExternalLink class="text-inherit inline w-[1.2em] h-[1.2em]" />
         </a>
+        <div v-else class="text-inherit">Simulation not public</div>
       </div>
 
       <TuneButton
@@ -177,25 +179,21 @@ async function simulate() {
         :tooltip="'Reset Simulation'"
         @click="resetState"
       >
-        Reset
+        Reset Simulation
         <IHoRefresh class="text-inherit w-[1em] h-[1em]" />
       </TuneButton>
-      <div
-        class="flex flex-col w-full items-start text-left"
-        v-if="simulationState.exceedsGasSubsidy"
-      >
-        <p class="text-sm">
-          <strong class="text-skins text-base text-red">Warning:</strong>
-          This transaction will
-          <strong class="underline"
-            >not be automatically executed by oSnap.</strong
-          >
-          This transaction used
-          {{ simulationState.gasUsed.toLocaleString() }} gas, which exceeds
-          oSnap's maximum subsidized amount of
-          {{ OSNAP_GAS_SUBSIDY.toLocaleString() }}.
-        </p>
-      </div>
+
+      <p v-if="simulationState.exceedsGasSubsidy" class="text-sm text-left">
+        <strong class="text-skins text-base text-red">Warning:</strong>
+        This transaction will
+        <strong class="underline"
+          >not be automatically executed by oSnap.</strong
+        >
+        This transaction used
+        {{ simulationState.gasUsed.toLocaleString() }} gas, which exceeds
+        oSnap's maximum subsidized amount of
+        {{ OSNAP_GAS_SUBSIDY.toLocaleString() }}.
+      </p>
     </div>
   </div>
 </template>

--- a/src/plugins/oSnap/components/TransactionBuilder/TenderlySimulation.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TenderlySimulation.vue
@@ -7,18 +7,14 @@ import {
   GnosisSafe,
   isErrorWithMessage
 } from '../../types';
-import { computed } from 'vue';
 import { ref } from 'vue';
 import {
   SIMULATION_ENDPOINT,
+  exceedsOsnapGasSubsidy,
   prepareTenderlySimulationPayload,
-  validatePayload
+  validatePayload,
+  OSNAP_GAS_SUBSIDY
 } from '../../utils/tenderly';
-
-// ERROR => unable to simulate
-// FAIL => tx Failed in simulation
-// SUCCESS =>  tx Succeeded in simulation
-type Status = 'SUCCESS' | 'FAIL' | 'ERROR' | 'LOADING' | 'IDLE';
 
 const props = defineProps<{
   transactions: TTransaction[];
@@ -26,21 +22,59 @@ const props = defineProps<{
   network: Network;
 }>();
 
-const simulationState = ref<Status>('IDLE');
-const simulationLink = ref<string>();
-const simulationError = ref<string>();
+type State =
+  | {
+      status: 'SUCCESS';
+      simulationLink: TenderlySimulationResult['resultUrl'];
+      gasUsed: TenderlySimulationResult['gasUsed'];
+      exceedsGasSubsidy: boolean;
+    }
+  | {
+      status: 'FAIL';
+      simulationLink: TenderlySimulationResult['resultUrl'];
+      gasUsed: TenderlySimulationResult['gasUsed'];
+      exceedsGasSubsidy: boolean;
+    }
+  | {
+      status: 'ERROR';
+      error: string;
+    }
+  | {
+      status: 'LOADING';
+    }
+  | {
+      status: 'IDLE';
+    };
+
+const simulationState = ref<State>({ status: 'IDLE' });
+
+const resetState = () => {
+  simulationState.value = { status: 'IDLE' };
+};
 
 function handleSimulationResult(res: TenderlySimulationResult) {
+  // if gas exceeds osnap gas subsidy, tx will not be automatically executed
+  const exceedsGasSubsidy = exceedsOsnapGasSubsidy(res);
+
   if (res.status === true) {
-    simulationState.value = 'SUCCESS';
+    simulationState.value = {
+      status: 'SUCCESS',
+      simulationLink: res.resultUrl,
+      gasUsed: res.gasUsed,
+      exceedsGasSubsidy
+    };
   } else {
-    simulationState.value = 'FAIL';
+    simulationState.value = {
+      status: 'FAIL',
+      simulationLink: res.resultUrl,
+      gasUsed: res.gasUsed,
+      exceedsGasSubsidy
+    };
   }
-  simulationLink.value = res.resultUrl.url;
 }
 
 async function simulate() {
-  simulationState.value = 'LOADING';
+  simulationState.value = { status: 'LOADING' };
   try {
     const payload = prepareTenderlySimulationPayload(props);
 
@@ -64,84 +98,104 @@ async function simulate() {
   } catch (error) {
     console.error(error);
     if (isErrorWithMessage(error)) {
-      simulationError.value = error.message;
+      simulationState.value = { status: 'ERROR', error: error.message };
+    } else {
+      simulationState.value = {
+        status: 'ERROR',
+        error: 'Failed to simulate!'
+      };
     }
-    simulationState.value = 'ERROR';
     await sleep(5_000);
-    simulationState.value = 'IDLE';
+    simulationState.value = {
+      status: 'IDLE'
+    };
   }
 }
-
-const errorMessage = simulationError ?? 'Failed to simulate!';
-
-const showResult = computed(() => {
-  return (
-    simulationState.value === 'FAIL' || simulationState.value === 'SUCCESS'
-  );
-});
-
-const resetState = () => {
-  simulationState.value = 'IDLE';
-  simulationLink.value = undefined;
-  simulationError.value = undefined;
-};
 </script>
 
 <template>
   <div>
     <button
-      v-if="!showResult"
+      v-if="
+        !(
+          simulationState.status === 'SUCCESS' ||
+          simulationState.status === 'FAIL'
+        )
+      "
       @click="simulate"
-      :disabled="simulationState !== 'IDLE'"
+      :disabled="simulationState.status !== 'IDLE'"
       :class="[
         'flex w-full enabled:hover:border-skin-text gap-2 justify-center h-[48px] px-[20px] items-center border disabled:cursor-not-allowed rounded-full border-skin-border',
         {
-          'text-red': simulationState === 'ERROR'
+          'text-red': simulationState.status === 'ERROR'
         }
       ]"
     >
       <IconTenderly class="text-skin-link inline h-[20px] w-[20px]" />
-      <span v-if="simulationState === 'IDLE'">Simulate Transaction</span>
-      <span v-if="simulationState === 'LOADING'">Checking transaction...</span>
-      <span class="text-xs" v-if="simulationState === 'ERROR'">{{
-        errorMessage
+      <span v-if="simulationState.status === 'IDLE'">Simulate Transaction</span>
+      <span v-if="simulationState.status === 'LOADING'"
+        >Checking transaction...</span
+      >
+      <span class="text-xs" v-if="simulationState.status === 'ERROR'">{{
+        simulationState.error
       }}</span>
 
-      <LoadingSpinner class="ml-auto" v-if="simulationState === 'LOADING'" />
+      <LoadingSpinner
+        class="ml-auto"
+        v-if="simulationState.status === 'LOADING'"
+      />
     </button>
-    <div class="flex flex-col gap-2" v-if="showResult">
+    <div class="flex flex-col gap-2" v-else>
       <div
         :class="[
           'flex w-full text-sm md:text-[18px] justify-between h-[48px] px-[20px] items-center rounded-full',
           {
-            'bg-green/20 text-green': simulationState === 'SUCCESS',
-            'bg-red/20 text-red': simulationState === 'FAIL'
+            'bg-green/20 text-green': simulationState.status === 'SUCCESS',
+            'bg-red/20 text-red': simulationState.status === 'FAIL'
           }
         ]"
       >
         <div class="flex items-center gap-2">
           <IconTenderly class="inline h-[20px] w-[20px] text-inherit" />
-          <span v-if="simulationState === 'SUCCESS'">Success!</span>
-          <span v-if="simulationState === 'FAIL'">Transaction failed!</span>
+          <span v-if="simulationState.status === 'SUCCESS'">Success!</span>
+          <span v-if="simulationState.status === 'FAIL'"
+            >Transaction failed!</span
+          >
         </div>
         <a
           target="_blank"
           class="flex items-center gap-1 text-inherit hover:underline"
-          :href="simulationLink"
+          :href="simulationState.simulationLink.url"
         >
           <span>View on Tenderly</span>
-          <IHoExternalLink class="text-inherit inline w-[1.2em] h-[1.2em]"
-        /></a>
+          <IHoExternalLink class="text-inherit inline w-[1.2em] h-[1.2em]" />
+        </a>
       </div>
+
       <TuneButton
         class="group text-sm md:text-[18px] hover:cursor-pointer justify-center w-full flex gap-2 mx-auto items-center"
         :tooltip="'Reset Simulation'"
-        v-if="showResult"
         @click="resetState"
       >
         Reset
         <IHoRefresh class="text-inherit w-[1em] h-[1em]" />
       </TuneButton>
+      <div
+        class="flex flex-col w-full items-start text-left"
+        v-if="simulationState.exceedsGasSubsidy"
+      >
+        <p class="text-sm">
+          <strong class="text-skins text-base text-red">Warning:</strong>
+          This transaction will
+          <strong class="underline"
+            >not be automatically executed by oSnap.</strong
+          >
+          This transaction used
+          {{ simulationState.gasUsed.toLocaleString() }} gas, which exceeds
+          oSnap's maximum subsidized amount of
+          {{ OSNAP_GAS_SUBSIDY.toLocaleString() }}.
+        </p>
+      </div>
     </div>
   </div>
 </template>

--- a/src/plugins/oSnap/utils/tenderly.ts
+++ b/src/plugins/oSnap/utils/tenderly.ts
@@ -2,7 +2,8 @@ import {
   OsnapPluginData,
   Transaction as TTransaction,
   GnosisSafe,
-  Network
+  Network,
+  TenderlySimulationResult
 } from '../types';
 import {
   validateModuleAddress,
@@ -11,6 +12,8 @@ import {
 
 export const SIMULATION_ENDPOINT =
   'https://ethereum-api-read-prod-77jg7zf4ea-ue.a.run.app/osnap/simulate';
+
+export const OSNAP_GAS_SUBSIDY = 500_000;
 
 export function validatePayload(data: OsnapPluginData): void | never {
   const { safe } = data;
@@ -52,4 +55,8 @@ export function prepareTenderlySimulationPayload(props: {
   };
 
   return { safe: payload };
+}
+
+export function exceedsOsnapGasSubsidy(res: TenderlySimulationResult): boolean {
+  return res.gasUsed > OSNAP_GAS_SUBSIDY;
 }


### PR DESCRIPTION
closes UMA-2168
closes UMA-2336

## motivation

oSnap will only subsidize 500_000 gas and execute transaction automatically. We want to show users a warning if their transaction is exceeding this limit.

> Note: This screenshot quotes the limit to be `50_000`, but this is only to force showing this warning. The actual figured hardcoded is `500_000`.

## screenshots
![Screenshot 2024-01-31 at 12 58 03](https://github.com/UMAprotocol/snapshot/assets/51655063/6e5b9524-1175-461f-aada-b311ddf7a1db)

> If the tenderly project is not public, don't share link. (this will likely not happen since we control the project and are always interacting with the OG contract)

![Screenshot 2024-01-31 at 17 14 20](https://github.com/UMAprotocol/snapshot/assets/51655063/351d913f-049c-4083-aa0d-3f5ad37252a2)

