### PR TITLE
add simulation in proposal view

### DIFF
--- a/src/plugins/oSnap/Proposal.vue
+++ b/src/plugins/oSnap/Proposal.vue
@@ -8,6 +8,7 @@ import ReadOnly from './components/Input/ReadOnly.vue';
 import SafeLinkWithAvatar from './components/SafeLinkWithAvatar.vue';
 import { GnosisSafe, Transaction } from './types';
 import OsnapMarketingWidget from './components/OsnapMarketingWidget.vue';
+import TenderlySimulation from './components/TransactionBuilder/TenderlySimulation.vue';
 
 const keyOrder = [
   'to',
@@ -59,9 +60,11 @@ function enrichTransactionForDisplay(transaction: Transaction) {
       ...commonProperties,
       type: 'Contract interaction',
       'method name': method.name,
-      ...Object.fromEntries(method.inputs.map((input,i)=>{
-        return [`${input.name} (param ${i+1}): `,parameters[i]]
-      }))
+      ...Object.fromEntries(
+        method.inputs.map((input, i) => {
+          return [`${input.name} (param ${i + 1}): `, parameters[i]];
+        })
+      )
     };
   }
   if (transaction.type === 'transferFunds') {
@@ -119,6 +122,12 @@ function enrichTransactionForDisplay(transaction: Transaction) {
           <span class="break-all">{{ value }}</span>
         </ReadOnly>
       </div>
+
+      <TenderlySimulation
+        :transactions="safe.transactions"
+        :safe="safe"
+        :network="safe.network"
+      />
 
       <HandleOutcome
         v-if="!!results"

--- a/src/plugins/oSnap/Proposal.vue
+++ b/src/plugins/oSnap/Proposal.vue
@@ -100,7 +100,7 @@ function enrichTransactionForDisplay(transaction: Transaction) {
 <template>
   <template v-if="safe.transactions.length > 0">
     <div
-      class="flex w-full flex-col gap-4 rounded-2xl border border-gray-200 p-3 md:p-4 relative"
+      class="flex w-full flex-col gap-4 rounded-2xl border border-skin-border p-3 md:p-4 relative"
     >
       <OsnapMarketingWidget class="absolute top-[-16px] right-[16px]" />
       <h2 class="text-lg">oSnap Transactions</h2>


### PR DESCRIPTION
## motivation

We want users to be able to run the simulation in the proposals view. 

## screenshots

<img width="667" alt="Screenshot 2024-02-01 at 13 09 25" src="https://github.com/UMAprotocol/snapshot/assets/51655063/fda9a0f1-1569-4d8a-a101-565c509b45f0">

<img width="663" alt="Screenshot 2024-02-01 at 13 09 33" src="https://github.com/UMAprotocol/snapshot/assets/51655063/27e58260-4cfc-4cdc-8456-57d5a115f0fe">

