### PR TITLE
Gerhard/uma 2372 fetch implementation abi if proxy

### DIFF
--- a/src/plugins/oSnap/utils/abi.ts
+++ b/src/plugins/oSnap/utils/abi.ts
@@ -91,11 +91,14 @@ export type AbiResult =
       error: string;
     };
 
-const usdcUpgradeable = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359';
-
+/**
+ * Attempts to fetch ABIs at a particular address, from a block explorer.
+ *
+ * Checks if the contract is a proxy contract, and if so, returns both
+ */
 export async function fetchProxyAndImplementationAbis(
   network: string,
-  contractAddress: string = usdcUpgradeable // for testing
+  contractAddress: string
 ): Promise<AbiResult> {
   try {
     const abi = await getContractABI(network, contractAddress);
@@ -118,12 +121,10 @@ export async function fetchProxyAndImplementationAbis(
     if (!implementationAddress) {
       throw new Error('Failed to fetch implementation address');
     }
-
     const implementationAbi = await getContractABI(
       network,
       implementationAddress
     );
-
     if (!implementationAbi) {
       throw new Error('failed to fetch implementation ABI');
     }
@@ -144,6 +145,11 @@ export async function fetchProxyAndImplementationAbis(
   }
 }
 
+/**
+ * Checks an ABI statically to see if it is a proxy contract.
+ *
+ * This is very rudimentary, it only checks if the contract has a function called "implementation"
+ */
 function isProxyContract(abi: string): boolean {
   const contract = new Interface(abi);
   if (

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -753,3 +753,17 @@ export function getOracleUiLink(
   }
   return `https://testnet.oracle.uma.xyz?transactionHash=${txHash}&eventIndex=${logIndex}`;
 }
+
+export async function fetchImplementationAddress(
+  abi: string,
+  proxyAddress: string,
+  network: string
+): Promise<string | undefined> {
+  try {
+    const provider = getProvider(network);
+    const proxyContract = new Contract(proxyAddress, abi, provider);
+    return (await proxyContract.implementation()) as string;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## motivation

DAOs might want to call functions on either the proxy contract OR the implementation contract for a given proposal.
atm users have 2 options:
1. paste in your own ABI manually 
2. pste in an address, in which case the app will ONLY fetch the proxy's ABI, which means the functions are limited to things like `changeAdmin()` or `upgrade()` etc.

We want to extend the fetching logic for proxy contracts, allowing for 3 possible options:
1. paste in your own ABI manually 
2. paste in an address, and fetch the proxy contract's ABI, list those "admin" functions.
3. Fetch the implementation ABI as well and list those functions.

The UX here has not been decided on, but for an initial draft I've gone the same route as etherscan, a familiar pattern for us to test with, giving the user a dropdown so they can choose between
- "Write contract"
- "Write as proxy"
