### PR TITLE
fix: ensure token lists and balances are loaded for new safe or network

### DIFF
--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -111,9 +111,13 @@ function enhanceTokensWithBalances(
     )
     .map(balance => enhanceTokenWithBalance(balance, tokens, network))
     .sort((a, b) => {
-      if (a.verified && b.verified) return 0;
-      if (a.verified) return -1;
-      return 1;
+      if (a.address === 'main' && b.address !== 'main') return -1;
+      if (!(a.address === 'main') && b.address === 'main') return 1;
+      if (a.verified && !b.verified) return -1;
+      if (!a.verified && b.verified) return +1;
+      if (!a.balance || !b.balance) return 0;
+      if (parseFloat(a.balance) > parseFloat(b.balance)) return -1;
+      return 0;
     });
 }
 

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -17,7 +17,8 @@ import {
   getGnosisSafeBalances,
   getGnosisSafeCollectibles,
   getIsOsnapEnabled,
-  getModuleAddressForTreasury
+  getModuleAddressForTreasury,
+  getNativeAsset
 } from './utils';
 import OsnapMarketingWidget from './components/OsnapMarketingWidget.vue';
 
@@ -77,21 +78,20 @@ async function fetchBalances(network: Network, safeAddress: string) {
   }
   try {
     const balances = await getGnosisSafeBalances(network, safeAddress);
+    const balancesWithNative = balances.map(balance => {
+      if (!balance.tokenAddress || !balance.token) {
+        return {
+          ...balance,
+          token: getNativeAsset(network),
+          tokenAddress: 'main'
+        };
+      }
+      return balance;
+    });
 
-    const uniswapTokensPromise = fetchTokens(
-      'https://gateway.ipfs.io/ipns/tokens.uniswap.org'
-    );
-    const snapshotTokensPromise = fetchTokens(
-      `${import.meta.env.VITE_SIDEKICK_URL}/api/moderation?list=verifiedTokens`
-    );
+    const tokens = await fetchTokens('https://tokens.uniswap.org');
 
-    const tokensLists = await Promise.all([
-      uniswapTokensPromise,
-      snapshotTokensPromise
-    ]);
-    const tokens = tokensLists.flat();
-
-    return enhanceTokensWithBalances(balances, tokens);
+    return enhanceTokensWithBalances(balancesWithNative, tokens, network);
   } catch (e) {
     console.warn('Error fetching balances');
     return [];
@@ -100,7 +100,8 @@ async function fetchBalances(network: Network, safeAddress: string) {
 
 function enhanceTokensWithBalances(
   balances: Partial<BalanceResponse>[],
-  tokens: Token[]
+  tokens: Token[],
+  network: Network
 ) {
   console.log({ balances, tokens });
   return balances
@@ -108,7 +109,7 @@ function enhanceTokensWithBalances(
       (balance): balance is BalanceResponse =>
         !!balance.token && !!balance.tokenAddress && !!balance.balance
     )
-    .map(balance => enhanceTokenWithBalance(balance, tokens))
+    .map(balance => enhanceTokenWithBalance(balance, tokens, network))
     .sort((a, b) => {
       if (a.verified && b.verified) return 0;
       if (a.verified) return -1;
@@ -119,7 +120,8 @@ function enhanceTokensWithBalances(
 // gets token balances and also determines if the token is verified
 function enhanceTokenWithBalance(
   balance: BalanceResponse,
-  tokens: Token[]
+  tokens: Token[],
+  network: Network
 ): Token {
   const verifiedToken = getVerifiedToken(balance.tokenAddress, tokens);
   return {
@@ -129,7 +131,7 @@ function enhanceTokenWithBalance(
       ? formatUnits(balance.balance, balance.token.decimals)
       : '0',
     verified: !!verifiedToken,
-    chainId: verifiedToken ? verifiedToken.chainId : undefined
+    chainId: network
   };
 }
 

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -199,8 +199,9 @@ const update = (newPluginData: OsnapPluginData) => {
   emit('update', { key: 'oSnap', form: newPluginData });
 };
 
-watch(newPluginData, async () => {
+async function loadBalancesAndCollectibles() {
   if (!newPluginData.value.safe?.safeAddress) return;
+  isLoading.value = true;
   tokens.value = await fetchBalances(
     newPluginData.value.safe.network,
     newPluginData.value.safe.safeAddress
@@ -209,20 +210,26 @@ watch(newPluginData, async () => {
     newPluginData.value.safe.network,
     newPluginData.value.safe.safeAddress
   );
-});
+
+  isLoading.value = false;
+}
+
+watch(
+  () => [
+    newPluginData.value.safe?.safeAddress,
+    newPluginData.value.safe?.network
+  ],
+  async () => {
+    await loadBalancesAndCollectibles();
+    update(newPluginData.value);
+  }
+);
 
 onMounted(async () => {
   isLoading.value = true;
   safes.value = await createOsnapEnabledSafes();
   newPluginData.value.safe = cloneDeep(safes.value[0]);
-  tokens.value = await fetchBalances(
-    newPluginData.value.safe.network,
-    newPluginData.value.safe.safeAddress
-  );
-  collectables.value = await fetchCollectibles(
-    newPluginData.value.safe.network,
-    newPluginData.value.safe.safeAddress
-  );
+  await loadBalancesAndCollectibles();
   update(newPluginData.value);
   isLoading.value = false;
 });

--- a/src/plugins/oSnap/components/TransactionBuilder/TokensModalItem.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TokensModalItem.vue
@@ -54,7 +54,7 @@ const exploreUrl = computed(() => {
     </div>
 
     <div class="h-full text-right">
-      <span v-if="token.address !== 'main'" class="text-skin-link">
+      <span class="text-skin-link">
         {{
           formatNumber(
             Number(token.balance),

--- a/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
@@ -34,7 +34,7 @@ const selectedTokenAddress = ref<Token['address']>(
 const selectedToken = computed(
   () =>
     tokens.value.find(token => token.address === selectedTokenAddress.value) ??
-    tokens.value.find(token => !token.address) ??
+    tokens.value.find(token => token.address === 'main') ??
     tokens.value[0]
 );
 

--- a/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TransferFunds.vue
@@ -23,10 +23,9 @@ const emit = defineEmits<{
   updateTransaction: [transaction: TransferFundsTransaction];
 }>();
 
-const nativeAsset = getNativeAsset(props.network);
 const amount = ref(props.transaction.amount ?? '');
 const recipient = ref(props.transaction.recipient ?? '');
-const tokens = ref<Token[]>([nativeAsset, ...props.tokens]);
+const tokens = ref<Token[]>(props.tokens);
 
 const selectedTokenAddress = ref<Token['address']>(
   props.transaction?.token?.address ?? 'main'
@@ -35,7 +34,8 @@ const selectedTokenAddress = ref<Token['address']>(
 const selectedToken = computed(
   () =>
     tokens.value.find(token => token.address === selectedTokenAddress.value) ??
-    nativeAsset
+    tokens.value.find(token => !token.address) ??
+    tokens.value[0]
 );
 
 const isTokenModalOpen = ref(false);

--- a/src/plugins/oSnap/utils/getters.ts
+++ b/src/plugins/oSnap/utils/getters.ts
@@ -54,7 +54,7 @@ async function callGnosisSafeTransactionApi<TResult = any>(
  */
 export const getGnosisSafeBalances = memoize(
   (network: Network, safeAddress: string) => {
-    const endpointPath = `/v1/safes/${safeAddress}/balances/`;
+    const endpointPath = `/v1/safes/${safeAddress}/balances?exclude_spam=true`;
     return callGnosisSafeTransactionApi<Partial<BalanceResponse>[]>(
       network,
       endpointPath


### PR DESCRIPTION
## fixes  UMA-2395 UMA-2388

## motivation

There was a bug in the transaction builder where the app would load all tokens you have balances for (your safe on a certain network), then when you switch safes, that list of tokens would not update. We also were not including the balance of the native token in the token chooser modal. This was because the balance pulled from gnosis, if that balance was for a native token it would be stripped out by the app, then later we just hardcoded in the native asset for the chain as an option, but without the balance info.

This PR rectifies some of the state management so that we relaod token balances and token lists when we switch safes.
It also ensures we keep the safe's balance for native tokens so we can display this data to the user.