### PR TITLE
fix: prevent page from crashing if no config found for network/safe

### DIFF
--- a/src/components/SettingsTreasuriesBlockItemButton.vue
+++ b/src/components/SettingsTreasuriesBlockItemButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { TreasuryWallet } from '@/helpers/interfaces';
 import { Network } from '@/plugins/oSnap/types';
-import { getIsOsnapEnabled } from '@/plugins/oSnap/utils/getters';
+import { ConfigError, getIsOsnapEnabled } from '@/plugins/oSnap/utils/getters';
 
 const props = defineProps<{
   treasury: TreasuryWallet;
@@ -17,13 +17,21 @@ const emit = defineEmits<{
 }>();
 
 const isOsnapEnabled = ref(false);
+const isChainSupported = ref(true);
 
 async function updateIsOsnapEnabled() {
   if (!props.hasOsnapPlugin) return;
-  isOsnapEnabled.value = await getIsOsnapEnabled(
+  const isEnabled = await getIsOsnapEnabled(
     props.treasury.network as Network,
     props.treasury.address
-  );
+  ).catch(e => {
+    if (e instanceof ConfigError) {
+      isChainSupported.value = false;
+      return false;
+    }
+    return false;
+  });
+  isOsnapEnabled.value = isEnabled;
 }
 
 onMounted(async () => {
@@ -47,12 +55,13 @@ onUnmounted(() => {
     </div>
     <div class="ml-auto mr-3">
       <SettingsTreasuryActivateOsnapButton
-        v-show="hasOsnapPlugin"
+        v-if="hasOsnapPlugin && isChainSupported"
         :is-osnap-enabled="isOsnapEnabled"
         @click.stop="
           !isViewOnly && emit('configureOsnap', treasuryIndex, isOsnapEnabled)
         "
       />
+      <div v-else>Unsupported chain</div>
     </div>
     <BaseButtonIcon
       v-show="!isViewOnly"

--- a/src/components/SettingsTreasuriesBlockItemButton.vue
+++ b/src/components/SettingsTreasuriesBlockItemButton.vue
@@ -61,7 +61,7 @@ onUnmounted(() => {
           !isViewOnly && emit('configureOsnap', treasuryIndex, isOsnapEnabled)
         "
       />
-      <div v-else>Unsupported chain</div>
+      <div v-else>oSnap unavailable</div>
     </div>
     <BaseButtonIcon
       v-show="!isViewOnly"

--- a/src/plugins/oSnap/types.ts
+++ b/src/plugins/oSnap/types.ts
@@ -533,3 +533,7 @@ export namespace GnosisSafe {
     components?: ContractInput[];
   }
 }
+
+export function nonNullable<T>(value: T): value is NonNullable<T> {
+  return value !== null;
+}

--- a/src/plugins/safeSnap/constants.ts
+++ b/src/plugins/safeSnap/constants.ts
@@ -33,7 +33,7 @@ export const EXPLORER_API_URLS = {
   '56': 'https://api.bscscan.com/api',
   '42161': 'https://api.arbiscan.io/api',
   // '1116': Add 'https://openapi.coredao.org/api' if API key requirement is removed
-  '11155111': 'https://api-sepolia.etherscan.io/api',
+  '11155111': 'https://api-sepolia.etherscan.io/api'
 };
 
 export const GNOSIS_SAFE_TRANSACTION_API_URLS = {
@@ -46,7 +46,7 @@ export const GNOSIS_SAFE_TRANSACTION_API_URLS = {
   '56': 'https://safe-transaction-bsc.safe.global/api',
   '42161': 'https://safe-transaction-arbitrum.safe.global/api',
   '1116': 'https://safetx.coredao.org/api',
-  '11155111': 'https://safe-transaction-sepolia.safe.global/api',
+  '11155111': 'https://safe-transaction-sepolia.safe.global/api'
 };
 
 // ABIs
@@ -400,7 +400,7 @@ export type ContractData = {
   network: string;
   name: string;
   address?: string;
-  deployBlockNumber?: number;
+  deployBlock?: number;
   subgraph?: string;
 };
 // contract addresses pulled from https://github.com/UMAprotocol/protocol/tree/master/packages/core/networks
@@ -567,5 +567,5 @@ export const contractData: ContractData[] = [
     deployBlock: 5421242,
     subgraph:
       'https://api.thegraph.com/subgraphs/name/reinis-frp/sepolia-optimistic-governor'
-  },
+  }
 ];


### PR DESCRIPTION
## motivation

also closes UMA-2549

We now load all safes that meet criteria:
- we have subgraphs for the network
- oSnap is enabled on that safe
- We can find the module address for the safe

In the case we can a safe defined in our space settings that does not meet these criteria, we just filter those out and display the ones that do. Show meaningful error in console.
