### PR TITLE
fix: hide redundant information about Token transfers in proposal page

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -204,3 +204,36 @@ export function toChecksumAddress(address: string) {
 export function addressEqual(address1: string, address2: string) {
   return address1.toLowerCase() === address2.toLowerCase();
 }
+
+export function objectFromEntriesSorted<T extends object>(
+  obj: T,
+  keyOrder: string[]
+) {
+  // set as array first to preserve the correct order
+  let entries = Object.entries(obj);
+  const sorted: Array<[string, T[keyof T]]> = [];
+
+  keyOrder.forEach(key => {
+    if (obj.hasOwnProperty(key)) {
+      sorted.push([key, obj[key]]);
+      entries = entries.filter(item => item[0] !== key);
+    }
+  });
+  // ensure we don't filter out any items we didn't explicitly sort
+  return [...sorted, ...entries];
+}
+
+export function pickFromObject<T extends object, K extends keyof T>(
+  obj: T,
+  keys: K[]
+): Pick<T, K> {
+  const picked: Partial<T> = {};
+
+  keys.forEach(key => {
+    if (obj.hasOwnProperty(key)) {
+      picked[key] = obj[key];
+    }
+  });
+
+  return picked as Pick<T, K>;
+}


### PR DESCRIPTION
## motivation

We are showing too much duplicate information about transfer transactions, this can be confusing.


## screenshots

**before**
![image (1)](https://github.com/UMAprotocol/snapshot/assets/51655063/f2eb0aa1-376e-471f-9a95-fc44606392be)

**after**
![Screenshot 2024-04-19 at 13 56 52](https://github.com/UMAprotocol/snapshot/assets/51655063/72a574bf-003f-437f-a5b7-df87990ac459)

