### PR TITLE
Feat multi safe proposals

### DIFF
--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -11,6 +11,7 @@ import {
 import { getIsOsnapEnabled, getModuleAddressForTreasury } from './utils';
 import CreateSafe from './CreateSafe.vue';
 import { toChecksumAddress } from '@/helpers/utils';
+import OsnapMarketingWidget from './components/OsnapMarketingWidget.vue';
 
 const props = defineProps<{
   space: ExtendedSpace;
@@ -131,58 +132,67 @@ onMounted(async () => {
 </script>
 
 <template>
-  <template v-if="!space.treasuries.length">
-    <h2>Warning: no treasuries</h2>
-    <p>
-      You have installed the oSnap plugin, but you don't have any treasuries.
-    </p>
-    <p>
-      Please add a Safe as a treasury and enable oSnap on it to use the oSnap
-      plugin.
-    </p>
-  </template>
-  <template v-else-if="hasLegacyPluginInstalled">
-    <div class="rounded-2xl border p-4 text-md">
+  <div class="rounded-2xl border border-skin-border relative">
+    <div v-if="!space.treasuries.length" class="rounded-2xl border p-4 text-md">
+      <h2>Warning: no treasuries</h2>
+      <p>
+        You have installed the oSnap plugin, but you don't have any treasuries.
+      </p>
+      <p>
+        Please add a Safe as a treasury and enable oSnap on it to use the oSnap
+        plugin.
+      </p>
+    </div>
+    <div
+      v-else-if="hasLegacyPluginInstalled"
+      class="rounded-2xl border p-4 text-md"
+    >
       <h2 class="mb-2">Warning: Multiple oSnap enabled plugins detected</h2>
       <p class="mb-2">
         For best experience using oSnap, please remove the SafeSnap plugin from
         your space.
       </p>
     </div>
-  </template>
 
-  <template v-else-if="isLoading">
-    <div class="grid min-h-[180px] place-items-center">
+    <div v-else-if="isLoading" class="grid min-h-[180px] place-items-center">
       <h2 class="text-center">
         Loading oSnap Safes <LoadingSpinner class="ml-2 inline" big />
       </h2>
     </div>
-  </template>
-  <template v-else-if="!allSafes.length">
-    <h2>Warning: no oSnap safes found</h2>
-    <p>
-      You have installed the oSnap plugin, but you don't have any oSnap safes.
-    </p>
-    <p>
-      Please add a Safe as a treasury and enable oSnap on it to use the oSnap
-      plugin.
-    </p>
-  </template>
-  <div class="flex flex-col gap-6" v-else>
-    <CreateSafe
-      v-for="(safe, i) in newPluginData.safes"
-      :key="`${safe.network}:${safe.safeAddress}`"
-      :safe="safe"
-      :all-safes="allSafes"
-      :unconfigured-safes="unconfiguredSafes"
-      @remove-safe="() => removeSafe(i)"
-      @update-safe="safe => updateSafe(safe, i)"
-    />
+    <div v-else-if="!allSafes.length">
+      <h2>Warning: no oSnap safes found</h2>
+      <p>
+        You have installed the oSnap plugin, but you don't have any oSnap safes.
+      </p>
+      <p>
+        Please add a Safe as a treasury and enable oSnap on it to use the oSnap
+        plugin.
+      </p>
+    </div>
+    <div
+      v-else-if="!newPluginData.safes?.length"
+      class="rounded-2xl border p-4 text-md"
+    >
+      <h4>Add treasuries to start building</h4>
+    </div>
+    <template v-else>
+      <CreateSafe
+        v-for="(safe, i) in newPluginData.safes"
+        :class="{ 'border-t border-skin-border': i !== 0 }"
+        :key="`${safe.network}:${safe.safeAddress}`"
+        :safe="safe"
+        :all-safes="allSafes"
+        :unconfigured-safes="unconfiguredSafes"
+        @remove-safe="() => removeSafe(i)"
+        @update-safe="safe => updateSafe(safe, i)"
+      />
+    </template>
+    <OsnapMarketingWidget class="absolute z-2 top-[-16px] right-[16px]" />
   </div>
   <TuneButton
     v-if="unconfiguredSafes.length"
     class="mt-4 w-full"
     @click="addNewSafe"
-    >Add Batch</TuneButton
+    >Add treasury +</TuneButton
   >
 </template>

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -1,28 +1,15 @@
 <script setup lang="ts">
 import { ExtendedSpace } from '@/helpers/interfaces';
-import { formatUnits } from '@ethersproject/units';
 import { cloneDeep } from 'lodash';
-import SelectSafe from './components/Input/SelectSafe.vue';
-import TransactionBuilder from './components/TransactionBuilder/TransactionBuilder.vue';
 import {
-  BalanceResponse,
   GnosisSafe,
-  NFT,
   Network,
   OsnapPluginData,
-  Token,
   Transaction,
   nonNullable
 } from './types';
-import {
-  getGnosisSafeBalances,
-  getGnosisSafeCollectibles,
-  getIsOsnapEnabled,
-  getModuleAddressForTreasury,
-  getNativeAsset
-} from './utils';
-import OsnapMarketingWidget from './components/OsnapMarketingWidget.vue';
-import BotSupportWarning from './components/BotSupportWarning.vue';
+import { getIsOsnapEnabled, getModuleAddressForTreasury } from './utils';
+import CreateSafe from './CreateSafe.vue';
 import { toChecksumAddress } from '@/helpers/utils';
 
 const props = defineProps<{
@@ -40,121 +27,36 @@ const emit = defineEmits<{
 }>();
 
 const newPluginData = ref<OsnapPluginData>({
-  safe: null
+  safes: null
 });
 
-const safes = ref<GnosisSafe[]>([]);
-const tokens = ref<Token[]>([]);
-const collectables = ref<NFT[]>([]);
+const updateSafes = (safes: GnosisSafe[]) => {
+  newPluginData.value = { safes };
+  emit('update', { key: 'oSnap', form: newPluginData.value });
+};
 
-function addTransaction(transaction: Transaction) {
-  if (newPluginData.value.safe === null) return;
-  newPluginData.value.safe.transactions.push(transaction);
-}
+const allSafes = ref<GnosisSafe[]>([]);
+const configuredSafes = computed(() => newPluginData.value.safes ?? []);
 
-function removeTransaction(transactionIndex: number) {
-  if (!newPluginData.value.safe) return;
-  newPluginData.value.safe.transactions.splice(transactionIndex, 1);
-}
-
-function updateTransaction(transaction: Transaction, transactionIndex: number) {
-  if (!newPluginData.value.safe) return;
-  newPluginData.value.safe.transactions[transactionIndex] = transaction;
-}
-
-async function fetchTokens(url: string): Promise<Token[]> {
-  try {
-    const response = await fetch(url);
-    const data = await response.json();
-    return data.verifiedTokens?.tokens || data.tokens || [];
-  } catch {
-    return [];
+const unconfiguredSafes = computed<GnosisSafe[]>(() => {
+  if (newPluginData.value?.safes?.length && configuredSafes.value.length) {
+    return allSafes.value.filter(safe =>
+      !!findSafe(safe, configuredSafes.value) ? false : true
+    );
   }
-}
+  return allSafes.value;
+});
 
-async function fetchBalances(network: Network, safeAddress: string) {
-  if (!safeAddress) {
-    return [];
-  }
-  try {
-    const balances = await getGnosisSafeBalances(network, safeAddress);
-    const balancesWithNative = balances.map(balance => {
-      if (!balance.tokenAddress || !balance.token) {
-        return {
-          ...balance,
-          token: getNativeAsset(network),
-          tokenAddress: 'main'
-        };
-      }
-      return balance;
-    });
-
-    const tokens = await fetchTokens('https://tokens.uniswap.org');
-
-    return enhanceTokensWithBalances(balancesWithNative, tokens, network);
-  } catch (e) {
-    console.warn('Error fetching balances', e);
-    return [];
-  }
-}
-
-function enhanceTokensWithBalances(
-  balances: Partial<BalanceResponse>[],
-  tokens: Token[],
-  network: Network
-) {
-  return balances
-    .filter(
-      (balance): balance is BalanceResponse =>
-        !!balance.token && !!balance.tokenAddress && !!balance.balance
-    )
-    .map(balance => enhanceTokenWithBalance(balance, tokens, network))
-    .sort((a, b) => {
-      if (a.address === 'main' && b.address !== 'main') return -1;
-      if (!(a.address === 'main') && b.address === 'main') return 1;
-      if (a.verified && !b.verified) return -1;
-      if (!a.verified && b.verified) return +1;
-      if (!a.balance || !b.balance) return 0;
-      if (parseFloat(a.balance) > parseFloat(b.balance)) return -1;
-      return 0;
-    });
-}
-
-// gets token balances and also determines if the token is verified
-function enhanceTokenWithBalance(
-  balance: BalanceResponse,
-  tokens: Token[],
-  network: Network
-): Token {
-  const verifiedToken = getVerifiedToken(balance.tokenAddress, tokens);
-  return {
-    ...balance.token,
-    address: balance.tokenAddress,
-    balance: balance.balance
-      ? formatUnits(balance.balance, balance.token.decimals)
-      : '0',
-    verified: !!verifiedToken,
-    chainId: network
-  };
-}
-
-function getVerifiedToken(tokenAddress: string, tokens: Token[]) {
-  return tokens.find(
-    token => token.address.toLowerCase() === tokenAddress.toLowerCase()
+function safeEqual(safe1: GnosisSafe, safe2: GnosisSafe): boolean {
+  return (
+    safe1.safeAddress === safe2.safeAddress && safe1.network === safe1.network
   );
 }
 
-async function fetchCollectibles(network: Network, gnosisSafeAddress: string) {
-  try {
-    const response = await getGnosisSafeCollectibles(
-      network,
-      gnosisSafeAddress
-    );
-    return response.results;
-  } catch (error) {
-    console.warn('Error fetching collectibles');
-  }
-  return [];
+function findSafe(safeToFind: GnosisSafe, from: GnosisSafe[]) {
+  return from.length
+    ? from.find(safe => safeEqual(safe, safeToFind))
+    : undefined;
 }
 
 // maps over the treasuries and creates a safe for each one
@@ -199,54 +101,47 @@ async function createOsnapEnabledSafes() {
   return safes;
 }
 
-// when changing safes, we create a whole new object and replace it
-function updateSafe(safe: GnosisSafe) {
-  newPluginData.value.safe = cloneDeep(safe);
-  update(newPluginData.value);
+function addSafeToConfigure(safe: GnosisSafe) {
+  updateSafes([...(newPluginData.value.safes ?? []), safe]);
 }
 
-const update = (newPluginData: OsnapPluginData) => {
-  emit('update', { key: 'oSnap', form: newPluginData });
-};
-
-async function loadBalancesAndCollectibles() {
-  if (!newPluginData.value.safe?.safeAddress) return;
-  isLoading.value = true;
-  tokens.value = await fetchBalances(
-    newPluginData.value.safe.network,
-    newPluginData.value.safe.safeAddress
-  );
-  collectables.value = await fetchCollectibles(
-    newPluginData.value.safe.network,
-    newPluginData.value.safe.safeAddress
-  );
-
-  isLoading.value = false;
+function addNewSafe() {
+  addSafeToConfigure(unconfiguredSafes.value[0]);
 }
 
-watch(
-  () => [
-    newPluginData.value.safe?.safeAddress,
-    newPluginData.value.safe?.network
-  ],
-  async () => {
-    await loadBalancesAndCollectibles();
-    update(newPluginData.value);
-  }
-);
+function removeSafe(safeIndex: number) {
+  const copy = [...configuredSafes.value];
+  copy.splice(safeIndex, 1);
+  updateSafes(copy);
+}
+
+function updateSafe(safe: GnosisSafe, safeIndex: number) {
+  const copy = [...configuredSafes.value];
+  copy[safeIndex] = safe;
+  updateSafes(copy);
+}
 
 onMounted(async () => {
   isLoading.value = true;
-  safes.value = await createOsnapEnabledSafes();
-  newPluginData.value.safe = cloneDeep(safes.value[0]);
-  await loadBalancesAndCollectibles();
-  update(newPluginData.value);
+  allSafes.value = await createOsnapEnabledSafes();
+  const initialSafe = cloneDeep(allSafes.value[0]);
+  updateSafes([initialSafe]);
   isLoading.value = false;
 });
 </script>
 
 <template>
-  <template v-if="hasLegacyPluginInstalled">
+  <template v-if="!space.treasuries.length">
+    <h2>Warning: no treasuries</h2>
+    <p>
+      You have installed the oSnap plugin, but you don't have any treasuries.
+    </p>
+    <p>
+      Please add a Safe as a treasury and enable oSnap on it to use the oSnap
+      plugin.
+    </p>
+  </template>
+  <template v-else-if="hasLegacyPluginInstalled">
     <div class="rounded-2xl border p-4 text-md">
       <h2 class="mb-2">Warning: Multiple oSnap enabled plugins detected</h2>
       <p class="mb-2">
@@ -255,66 +150,39 @@ onMounted(async () => {
       </p>
     </div>
   </template>
-  <template v-else>
-    <div v-if="isLoading" class="grid min-h-[180px] place-items-center">
+
+  <template v-else-if="isLoading">
+    <div class="grid min-h-[180px] place-items-center">
       <h2 class="text-center">
         Loading oSnap Safes <LoadingSpinner class="ml-2 inline" big />
       </h2>
     </div>
-    <div v-else class="rounded-2xl border p-4 relative">
-      <OsnapMarketingWidget class="absolute top-[-16px] right-[16px]" />
-      <template v-if="space.treasuries.length === 0">
-        <h2>Warning: no treasuries</h2>
-        <p>
-          You have installed the oSnap plugin, but you don't have any
-          treasuries.
-        </p>
-        <p>
-          Please add a Safe as a treasury and enable oSnap on it to use the
-          oSnap plugin.
-        </p>
-      </template>
-      <template v-else-if="safes.length === 0">
-        <h2>Warning: no oSnap safes found</h2>
-        <p>
-          You have installed the oSnap plugin, but you don't have any oSnap
-          safes.
-        </p>
-        <p>
-          Please add a Safe as a treasury and enable oSnap on it to use the
-          oSnap plugin.
-        </p>
-      </template>
-      <template v-else>
-        <h2 class="text-md">Add oSnap transactions</h2>
-        <h3 class="text-base">Pick a safe</h3>
-        <SelectSafe
-          :safes="safes"
-          :selectedSafe="newPluginData.safe"
-          @updateSafe="updateSafe($event)"
-        />
-        <BotSupportWarning
-          v-if="newPluginData.safe"
-          :safe-address="newPluginData.safe?.safeAddress"
-          :chain-id="newPluginData.safe?.network"
-        />
-        <div class="mt-4 border-b last:border-b-0">
-          <TransactionBuilder
-            v-if="!!newPluginData.safe"
-            :space="space"
-            :safe-address="newPluginData.safe.safeAddress"
-            :module-address="newPluginData.safe.moduleAddress"
-            :tokens="tokens"
-            :collectables="collectables"
-            :network="newPluginData.safe.network"
-            :transactions="newPluginData.safe.transactions"
-            :safe="newPluginData.safe"
-            @add-transaction="addTransaction"
-            @remove-transaction="removeTransaction"
-            @update-transaction="updateTransaction"
-          />
-        </div>
-      </template>
-    </div>
   </template>
+  <template v-else-if="!allSafes.length">
+    <h2>Warning: no oSnap safes found</h2>
+    <p>
+      You have installed the oSnap plugin, but you don't have any oSnap safes.
+    </p>
+    <p>
+      Please add a Safe as a treasury and enable oSnap on it to use the oSnap
+      plugin.
+    </p>
+  </template>
+  <div class="flex flex-col gap-6" v-else>
+    <CreateSafe
+      v-for="(safe, i) in newPluginData.safes"
+      :key="`${safe.network}:${safe.safeAddress}`"
+      :safe-index="i"
+      :safe="safe"
+      @remove-safe="removeSafe"
+      @update-safe="updateSafe"
+      :all-safes="allSafes"
+    />
+  </div>
+  <TuneButton
+    v-if="unconfiguredSafes.length"
+    class="mt-4 w-full"
+    @click="addNewSafe"
+    >Add Batch</TuneButton
+  >
 </template>

--- a/src/plugins/oSnap/Create.vue
+++ b/src/plugins/oSnap/Create.vue
@@ -172,11 +172,11 @@ onMounted(async () => {
     <CreateSafe
       v-for="(safe, i) in newPluginData.safes"
       :key="`${safe.network}:${safe.safeAddress}`"
-      :safe-index="i"
       :safe="safe"
-      @remove-safe="removeSafe"
-      @update-safe="updateSafe"
       :all-safes="allSafes"
+      :unconfigured-safes="unconfiguredSafes"
+      @remove-safe="() => removeSafe(i)"
+      @update-safe="safe => updateSafe(safe, i)"
     />
   </div>
   <TuneButton

--- a/src/plugins/oSnap/CreateSafe.vue
+++ b/src/plugins/oSnap/CreateSafe.vue
@@ -10,12 +10,12 @@ import BotSupportWarning from './components/BotSupportWarning.vue';
 // PROPS
 const props = defineProps<{
   allSafes: GnosisSafe[];
+  unconfiguredSafes: GnosisSafe[];
   safe: GnosisSafe;
-  safeIndex: number;
 }>();
 
 // VARS
-const configuredSafe = ref<GnosisSafe | null>(null);
+const configuredSafe = ref<GnosisSafe>();
 const tokens = ref<Token[]>([]);
 const collectibles = ref<NFT[]>([]);
 const isLoading = ref(false);
@@ -24,20 +24,20 @@ const isLoading = ref(false);
 
 // emits an event with the shape expected by the parent of the plugin component
 const emit = defineEmits<{
-  updateSafe: [value: GnosisSafe, index: number];
+  updateSafe: [value: GnosisSafe];
   addSafe: [value: GnosisSafe];
-  removeSafe: [value: number];
+  removeSafe: [];
 }>();
 
 // METHODS
 function update(newlyConfiguredSafe: GnosisSafe) {
-  emit('updateSafe', newlyConfiguredSafe, props.safeIndex);
+  emit('updateSafe', newlyConfiguredSafe);
 }
 
 // METHODS
 function removeSafe() {
   if (configuredSafe.value) {
-    emit('removeSafe', props.safeIndex);
+    emit('removeSafe');
   }
 }
 
@@ -49,7 +49,7 @@ function replaceSafe(safe: GnosisSafe | null) {
 }
 
 function addTransaction(transaction: Transaction) {
-  if (configuredSafe.value === null) return;
+  if (!configuredSafe.value) return;
   configuredSafe.value.transactions.push(transaction);
 }
 
@@ -108,8 +108,8 @@ onMounted(async () => {
     <h2 class="text-md">Add oSnap transactions</h2>
     <h3 class="text-base">Pick a safe</h3>
     <SelectSafe
-      :safes="allSafes"
-      :selectedSafe="configuredSafe"
+      :safes="[...unconfiguredSafes, configuredSafe ?? props.safe]"
+      :selectedSafe="configuredSafe ?? props.safe"
       @updateSafe="replaceSafe($event)"
     />
     <BotSupportWarning

--- a/src/plugins/oSnap/CreateSafe.vue
+++ b/src/plugins/oSnap/CreateSafe.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { GnosisSafe, NFT, Token, Transaction } from './types';
+import { fetchBalances, fetchCollectibles } from './utils';
+import { cloneDeep } from 'lodash';
+import SelectSafe from './components/Input/SelectSafe.vue';
+import TransactionBuilder from './components/TransactionBuilder/TransactionBuilder.vue';
+import OsnapMarketingWidget from './components/OsnapMarketingWidget.vue';
+import BotSupportWarning from './components/BotSupportWarning.vue';
+
+// PROPS
+const props = defineProps<{
+  allSafes: GnosisSafe[];
+  safe: GnosisSafe;
+  safeIndex: number;
+}>();
+
+// VARS
+const configuredSafe = ref<GnosisSafe | null>(null);
+const tokens = ref<Token[]>([]);
+const collectibles = ref<NFT[]>([]);
+const isLoading = ref(false);
+
+// EMITS
+
+// emits an event with the shape expected by the parent of the plugin component
+const emit = defineEmits<{
+  updateSafe: [value: GnosisSafe, index: number];
+  addSafe: [value: GnosisSafe];
+  removeSafe: [value: number];
+}>();
+
+// METHODS
+function update(newlyConfiguredSafe: GnosisSafe) {
+  emit('updateSafe', newlyConfiguredSafe, props.safeIndex);
+}
+
+// METHODS
+function removeSafe() {
+  if (configuredSafe.value) {
+    emit('removeSafe', props.safeIndex);
+  }
+}
+
+// when changing safes, we create a whole new object and replace it
+function replaceSafe(safe: GnosisSafe | null) {
+  if (!safe) return;
+  configuredSafe.value = cloneDeep(safe);
+  update(configuredSafe.value);
+}
+
+function addTransaction(transaction: Transaction) {
+  if (configuredSafe.value === null) return;
+  configuredSafe.value.transactions.push(transaction);
+}
+
+function removeTransaction(transactionIndex: number) {
+  if (!configuredSafe.value) return;
+  configuredSafe.value.transactions.splice(transactionIndex, 1);
+}
+
+function updateTransaction(transaction: Transaction, transactionIndex: number) {
+  if (!configuredSafe.value) return;
+  configuredSafe.value.transactions[transactionIndex] = transaction;
+}
+
+// fetch tokens and nfts for selected safe
+async function loadBalancesAndCollectibles() {
+  if (!configuredSafe.value?.safeAddress) return;
+  isLoading.value = true;
+  tokens.value = await fetchBalances(
+    configuredSafe.value.network,
+    configuredSafe.value.safeAddress
+  );
+  collectibles.value = await fetchCollectibles(
+    configuredSafe.value.network,
+    configuredSafe.value.safeAddress
+  );
+  isLoading.value = false;
+}
+
+async function loadBalancesAndUpdate() {
+  isLoading.value = true;
+  // fetch tokens and nfts
+  await loadBalancesAndCollectibles();
+  isLoading.value = false;
+
+  if (configuredSafe.value) {
+    update(configuredSafe.value);
+  }
+}
+
+watch(
+  () => [configuredSafe.value?.safeAddress, configuredSafe.value?.network],
+  loadBalancesAndUpdate
+);
+
+onMounted(async () => {
+  // take the first safe available
+  configuredSafe.value = cloneDeep(props.safe);
+  loadBalancesAndUpdate();
+});
+</script>
+
+<template>
+  <div class="rounded-2xl border p-4 relative">
+    <OsnapMarketingWidget class="absolute top-[-16px] right-[16px]" />
+    <button class="text-red" @click="removeSafe">Remove Batch</button>
+    <h2 class="text-md">Add oSnap transactions</h2>
+    <h3 class="text-base">Pick a safe</h3>
+    <SelectSafe
+      :safes="allSafes"
+      :selectedSafe="configuredSafe"
+      @updateSafe="replaceSafe($event)"
+    />
+    <BotSupportWarning
+      v-if="configuredSafe"
+      :safe-address="configuredSafe.safeAddress"
+      :chain-id="configuredSafe.network"
+    />
+    <div class="mt-4 border-b last:border-b-0">
+      <TransactionBuilder
+        v-if="!!configuredSafe"
+        :safe="configuredSafe"
+        :tokens="tokens"
+        :collectibles="collectibles"
+        @add-transaction="addTransaction"
+        @remove-transaction="removeTransaction"
+        @update-transaction="updateTransaction"
+      />
+    </div>
+  </div>
+</template>

--- a/src/plugins/oSnap/CreateSafe.vue
+++ b/src/plugins/oSnap/CreateSafe.vue
@@ -4,7 +4,6 @@ import { fetchBalances, fetchCollectibles } from './utils';
 import { cloneDeep } from 'lodash';
 import SelectSafe from './components/Input/SelectSafe.vue';
 import TransactionBuilder from './components/TransactionBuilder/TransactionBuilder.vue';
-import OsnapMarketingWidget from './components/OsnapMarketingWidget.vue';
 import BotSupportWarning from './components/BotSupportWarning.vue';
 
 // PROPS
@@ -102,9 +101,10 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="rounded-2xl border p-4 relative">
-    <OsnapMarketingWidget class="absolute top-[-16px] right-[16px]" />
-    <button class="text-red" @click="removeSafe">Remove Batch</button>
+  <div class="flex p-4 flex-col gap-0 relative pb-4">
+    <button class="text-red ml-auto" @click="removeSafe">
+      Remove treasury
+    </button>
     <h2 class="text-md">Add oSnap transactions</h2>
     <h3 class="text-base">Pick a safe</h3>
     <SelectSafe

--- a/src/plugins/oSnap/Proposal.vue
+++ b/src/plugins/oSnap/Proposal.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ExtendedSpace, Proposal, Results } from '@/helpers/interfaces';
-import { getIpfsUrl } from '@/helpers/utils';
 import { isBigNumberish } from '@ethersproject/bignumber/lib/bignumber';
 import { formatEther, formatUnits } from '@ethersproject/units';
 import HandleOutcome from './components/HandleOutcome/HandleOutcome.vue';
@@ -40,8 +39,6 @@ const props = defineProps<{
   proposal: Proposal;
   results: Results;
 }>();
-
-const ipfs = getIpfsUrl(props.proposal.ipfs) as string;
 
 const safes = computed<GnosisSafe[]>(() => {
   if (isLegacySingleSafe(props.proposal.plugins.oSnap)) {

--- a/src/plugins/oSnap/components/HandleOutcome/HandleOutcome.vue
+++ b/src/plugins/oSnap/components/HandleOutcome/HandleOutcome.vue
@@ -77,11 +77,7 @@ const hasSufficientBalance = computed(() => {
     return undefined;
   return userCollateralBalance.value.gte(ogModuleDetails.value.minimumBond);
 });
-const {
-  createPendingTransaction,
-  updatePendingTransaction,
-  removePendingTransaction
-} = useTxStatus();
+const { createPendingTransaction, removePendingTransaction } = useTxStatus();
 const { notify } = useFlashNotification();
 const { quorum } = useQuorum(props);
 
@@ -225,9 +221,7 @@ async function onExecuteProposal() {
 }
 
 const connectedToRightChain = computed(() => {
-  return (
-    Number(getInstance().provider.value?.chainId) === Number(props.network)
-  );
+  return Number(props.network) === Number(web3.value.network.chainId);
 });
 
 const networkName = computed(() => {
@@ -305,7 +299,7 @@ async function ensureRightNetwork(chainId: Network) {
   }
 }
 
-onMounted(async () => {
+async function loadActions() {
   collateralDetails.value = await getCollateralDetailsForProposal(
     provider,
     props.moduleAddress
@@ -326,6 +320,10 @@ onMounted(async () => {
     props.moduleAddress
   );
   await updateOgProposalState();
+}
+
+onMounted(async () => {
+  loadActions();
 });
 </script>
 

--- a/src/plugins/oSnap/components/TransactionBuilder/Transaction.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/Transaction.vue
@@ -61,13 +61,20 @@ function setTransactionAsInvalid() {
 </script>
 
 <template>
-  <div class="mt-4 border-b pb-4 first:mt-0">
-    <div class="flex items-center justify-between text-[#FF5353]">
+  <div class="mt-4 pb-4 first:mt-0">
+    <div class="flex items-center justify-between">
       <h3 class="text-left text-base">
         Transaction {{ transactionIndex + 1 }}
       </h3>
-      <button @click="emit('removeTransaction', transactionIndex)">
-        Remove
+      <button
+        class="p-[6px] transition-colors duration-200 group"
+        @click="emit('removeTransaction', transactionIndex)"
+      >
+        <BaseIcon
+          class="text-red/80 group-hover:text-red"
+          name="close"
+          size="14"
+        />
       </button>
     </div>
     <TransactionType

--- a/src/plugins/oSnap/components/TransactionBuilder/TransactionBuilder.vue
+++ b/src/plugins/oSnap/components/TransactionBuilder/TransactionBuilder.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import { ExtendedSpace, Proposal, Results } from '@/helpers/interfaces';
 import { shorten } from '@/helpers/utils';
 import {
   GnosisSafe,
   NFT,
-  Network,
   SafeImportTransaction,
   Transaction as TTransaction,
   Token
@@ -15,16 +13,9 @@ import TenderlySimulation from './TenderlySimulation.vue';
 import TransactionImport from './TransactionImport.vue';
 
 const props = defineProps<{
-  safeAddress: string;
-  moduleAddress: string;
   tokens: Token[];
-  collectables: NFT[];
-  network: Network;
-  transactions: TTransaction[];
-  proposal?: Proposal;
-  space: ExtendedSpace;
-  results?: Results;
-  safe: GnosisSafe | null;
+  collectibles: NFT[];
+  safe: GnosisSafe;
 }>();
 
 const emit = defineEmits<{
@@ -34,7 +25,7 @@ const emit = defineEmits<{
 }>();
 
 const safeLink = computed(() =>
-  getSafeAppLink(props.network, props.safeAddress)
+  getSafeAppLink(props.safe.network, props.safe.safeAddress)
 );
 
 function addImportedTransactions(transactions: SafeImportTransaction[]) {
@@ -50,44 +41,44 @@ function addImportedTransactions(transactions: SafeImportTransaction[]) {
       class="ml-2 inline-flex font-normal text-skin-text"
       target="_blank"
     >
-      {{ shorten(safeAddress) }}
+      {{ shorten(safe.safeAddress) }}
       <i-ho-external-link class="ml-1" />
     </a>
   </p>
   <p class="my-2">
     <strong>Module address</strong
     ><span class="ml-2 inline-block break-all">{{
-      shorten(moduleAddress)
+      shorten(safe.moduleAddress)
     }}</span>
   </p>
   <p class="my-2">
     <strong>Number of transactions</strong
-    ><span class="ml-2 inline-block">{{ transactions.length }}</span>
+    ><span class="ml-2 inline-block">{{ safe.transactions.length }}</span>
     <TransactionImport
       @update:imported-transactions="addImportedTransactions"
       :safe="props.safe"
-      :network="props.network"
+      :network="safe.network"
     />
   </p>
   <div class="text-center">
     <Transaction
-      v-for="(transaction, index) in transactions"
+      v-for="(transaction, index) in safe.transactions"
       :key="index"
       :transaction="transaction"
       :transaction-index="index"
-      :safe-address="safeAddress"
-      :module-address="moduleAddress"
+      :safe-address="safe.safeAddress"
+      :module-address="safe.moduleAddress"
       :tokens="tokens"
-      :collectables="collectables"
-      :network="props.network"
+      :collectables="collectibles"
+      :network="safe.network"
       @update-transaction="(...args) => emit('updateTransaction', ...args)"
       @remove-transaction="(...args) => emit('removeTransaction', ...args)"
     />
     <TenderlySimulation
-      v-if="transactions.length"
-      :transactions="transactions"
+      v-if="safe.transactions.length"
+      :transactions="safe.transactions"
       :safe="props.safe"
-      :network="props.network"
+      :network="safe.network"
       class="mt-4"
     />
   </div>

--- a/src/plugins/oSnap/types.ts
+++ b/src/plugins/oSnap/types.ts
@@ -254,12 +254,20 @@ export type GnosisSafe = {
  *
  * Holds one object with this shape per proposal created. This is the shape of the data that is persisted by the plugin.
  *
- * `safe` is null when first creating a plugin, but is then immediately populated once the user picks a safe.
+ * `safes` is null when first creating a plugin, but is then immediately populated once the user picks a safe.
  *
- * @field `safe` field is the safe that the plugin is currently working with.
+ * @field `safes` field is the array of safes that the plugin is currently working with.
  */
-export type OsnapPluginData = {
+export type OsnapPluginData = MultiSafe;
+
+export type LegacyOsnapPluginData = SingleSafe;
+
+type MultiSafe = {
   safes: GnosisSafe[] | null;
+};
+
+type SingleSafe = {
+  safe: GnosisSafe | null;
 };
 
 /**
@@ -536,4 +544,11 @@ export namespace GnosisSafe {
 
 export function nonNullable<T>(value: T): value is NonNullable<T> {
   return value !== null;
+}
+
+//  for backwards compatibility
+export function isLegacySingleSafe(
+  pluginData: LegacyOsnapPluginData | OsnapPluginData
+): pluginData is LegacyOsnapPluginData {
+  return 'safe' in pluginData;
 }

--- a/src/plugins/oSnap/types.ts
+++ b/src/plugins/oSnap/types.ts
@@ -259,7 +259,7 @@ export type GnosisSafe = {
  * @field `safe` field is the safe that the plugin is currently working with.
  */
 export type OsnapPluginData = {
-  safe: GnosisSafe | null;
+  safes: GnosisSafe[] | null;
 };
 
 /**

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -141,16 +141,19 @@ const isFormValid = computed(() => {
     : true;
 
   const isOsnapPluginValid = (() => {
-    const osnapData = form.value.metadata.plugins.oSnap?.safe;
-    if (!osnapData) {
+    const safes = form.value.metadata.plugins.oSnap?.safes;
+    if (!safes) {
       //  not using osnap plugin
       return true;
     }
-    if (osnapData && !(osnapData.transactions.length > 0)) {
-      //  using osnap, but no transactions
+    if (safes.length && safes.some(safe => !(safe.transactions.length > 0))) {
+      //  using osnap, but some have no transactions
       return false;
     }
-    if (osnapData && !osnapData.transactions.every(tx => tx.isValid)) {
+    if (
+      safes &&
+      !safes.every(safe => safe.transactions.every(tx => tx.isValid))
+    ) {
       //  all transactions must be valid
       return false;
     }


### PR DESCRIPTION
closes UMA-2555

## motivation

We want to let users create proposals for safes on different network. 
Most of the logic is kept the same here. 
For each oSnap enabled safe we can find for the space, we allow them to create a set of transactions, as normal.
In the proposal page each safe is displayed separately listing its transactions, as normal.
Tenderly sims also remain on a per-safe basis.

